### PR TITLE
[WIP] ideas for syncing validator set from one chain to another as well as making bridge work with dynamic validator sets

### DIFF
--- a/contracts/bridged_validator_set.sol
+++ b/contracts/bridged_validator_set.sol
@@ -1,0 +1,54 @@
+// a validator set that is synchronized from another chain
+// using the validator set itself to validate synchronization
+// (draft, don't use, needs tests, audit, static analysis)
+contract BridgedValidatorSet {
+    address[] public validatorSet;
+    // maps hash of a requested new validator set (+ blockNumber) 
+    // to the addresses of validators that have signed off on the change
+    mapping (bytes32 => address[]) changeRequests;
+    uint256 requiredSignatures;
+    uint256 blockNumberOfLastSyncedChange;
+
+    function SyncedValidatorSet(address[] initialValidatorSet, uint256 requiredSignaturesCount) {
+        validatorSet = initialValidatorSet;
+        requiredSignaturesCount = requiredSignaturesCount;
+        // initially accept change from any block number
+        blockNumberOfLastSyncedChange = 0;
+    }
+
+    function getValidators() constant returns (address[]) {
+        return validatorSet;
+    }
+
+    function calledByBridgeOnChangeFinalizedEvent(address[] newValidatorSet, uint256 blockNumberOfChange) {
+        // only senders that are currently validators can call this function
+        require(validatorSet.contains(msg.sender));
+        // ensure that we don't go back to a previous change if
+        // transactions get mined out of order.
+        // treat transactions within the same block as having the same priority.
+        // could add transactionIndex to distinguish transactions within block.
+        require(blockNumberOfLastSyncedChange <= blockNumberOfChange);
+
+        // unique hash for this change
+        bytes32 changeHash = sha3(newValidatorSet, blockNumberOfChange);
+        // prevent misbehaving bridge processes from
+        // calling this function twice with the same change request
+        require(!changeRequests[changeHash].contains(msg.sender));
+
+        // remember that this validator has signed off on the change
+        changeRequests[changeHash].push(msg.sender);
+
+        if (changeRequests[changeHash].length == requiredSignatures) {
+            // enough validators from current validator set
+            // have signed off (called this function) on the exact
+            // same (ensured by changeHash) new validator set
+            validatorSet = newValidatorSet;
+            blockNumberOfLastSyncedChange = blockNumberOfChange;
+            // collect garbage
+            delete changeRequests[changeHash];
+            ChangeFinalized(newValidatorSet);
+        }
+    }
+
+    event ChangeFinalized(address[] current_set);
+}

--- a/contracts/bridged_validator_set.sol
+++ b/contracts/bridged_validator_set.sol
@@ -38,7 +38,7 @@ contract BridgedValidatorSet {
         // remember that this validator has signed off on the change
         changeRequests[changeHash].push(msg.sender);
 
-        if (changeRequests[changeHash].length == requiredSignatures) {
+        if (changeRequests[changeHash].length == requiredSignaturesCount) {
             // enough validators from current validator set
             // have signed off (called this function) on the exact
             // same (ensured by changeHash) new validator set

--- a/contracts/bridged_validator_set.sol
+++ b/contracts/bridged_validator_set.sol
@@ -9,7 +9,7 @@ contract BridgedValidatorSet {
     uint256 requiredSignatures;
     uint256 blockNumberOfLastSyncedChange;
 
-    function SyncedValidatorSet(address[] initialValidatorSet, uint256 requiredSignaturesCount) {
+    function BridgedValidatorSet(address[] initialValidatorSet, uint256 requiredSignaturesCount) {
         validatorSet = initialValidatorSet;
         requiredSignaturesCount = requiredSignaturesCount;
         // initially accept change from any block number

--- a/contracts/bridged_validator_set.sol
+++ b/contracts/bridged_validator_set.sol
@@ -20,7 +20,7 @@ contract BridgedValidatorSet {
         return validatorSet;
     }
 
-    function calledByBridgeOnChangeFinalizedEvent(address[] newValidatorSet, uint256 blockNumberOfChange) {
+    function calledByValidatorProcessOnChangeFinalizedEvent(address[] newValidatorSet, uint256 blockNumberOfChange) {
         // only senders that are currently validators can call this function
         require(validatorSet.contains(msg.sender));
         // ensure that we don't go back to a previous change if

--- a/docs/bridge_with_dynamic_validator_set.md
+++ b/docs/bridge_with_dynamic_validator_set.md
@@ -1,3 +1,22 @@
+# modifications required to bridge in order to make it work with dynamic validator sets
+
+the parity-bridge currently (2017-11-16 / [740601530096c261695ba9216b5e9d5f871a229f](https://github.com/paritytech/parity-bridge/commit/740601530096c261695ba9216b5e9d5f871a229f))
+has a hardcoded list of authorities.
+
+we want to switch to a dynamic validator set represented on `foreign_chain` by
+a contract implementing the `ValidatorSet` interface.
+
+the approach laid out in this document depends on a `BridgedValidatorSet`,
+as described in [bridged_validator_set.md](bridged_validator_set.md),
+is present and synced on `home_chain`.
+
+this means that contracts on `home_chain` can call `home_chain.BridgedValidatorSet.getValidatorSet()`
+to obtain the newest synced version of `foreign_chain.ValidatorSet.getValidatorSet()`.
+
+## problem
+
+## how do we detect that the validator set has changed
+
 ## problem: validator set has changed while relay-transaction from foreign_chain to home_chain was in flight
 
 ### possible solution 1

--- a/docs/bridge_with_dynamic_validator_set.md
+++ b/docs/bridge_with_dynamic_validator_set.md
@@ -1,0 +1,151 @@
+## problem: validator set has changed while relay-transaction from foreign_chain to home_chain was in flight
+
+### possible solution 1
+
+`ForeignBridgeContract` and `HomeBridgeContract` keep a hash of the addresses
+of the current validator set.
+hash is either computed every time the validator set changes (to save gas)
+or computed every time it's needed.
+that hash is sent with every relay transaction (deposit, message).
+
+on the last operation that will settle the relay-operation on the target chain
+that hash is compared with the hash of the current validator set.
+
+if the hashes match then the relay-operation is completed.
+if the hashes differ then the relay-operation is retried.
+
+i'd prefer a hash.
+it uses more gas every time but it 
+
+#### required decision on edge case
+
+it matters whether the 
+
+## problem: how to retry relay-transaction of home_chain -> foreign_chain (deposit) relay-transaction
+
+### possible solution 1
+
+to `ForeignBridgeContract.deposit()`
+add param `validatorSetHash`
+
+remove modifier `onlyAuthority`
+instead just collect information about it
+in order to be able to distinguish misbehaving validators from
+
+retry until we have `requiredSignatures` verifiable signatures from 
+the validator set that is current validator set of ForeignChain.
+
+remember those 
+
+once we have n signatures that belong to the same validator
+
+if there's n signatures and the validator set hash matches and
+we can verify all signatures we got then allow it
+
+otherwise it should be in a state where it will eventually retry the transaction
+
+emit `RetryDeposit` event. picked up by validators.
+by that point in time the `ValidatorChange` should be completed.
+
+calls `HomeChain.retryDeposit(transactionHash)`:
+first come first serve of validators.
+but validator must be in authority set.
+required that transaction has already been deposited once.
+this makes the `HomeChainContract` emit a `Deposit` event again
+which is picked up by the bridges
+
+**this doesn't work because HomeChain can't access & check
+transactionHash which opens up DOS vector.**
+
+retry only works for things that have already made it to the other side.
+initialize retry from the other side.
+
+conditions for retry:
+certain age?
+
+retry 
+
+this can be repeated indefinitely but only once per validator_set_hash.
+
+make things unique by tuple `transaction_hash, validator_set_hash`.
+
+**both old and new validator set must have more than requiredSignatures members.
+otherwise it will be stuck**
+
+working backwards from that.
+
+`ForeignBridgeContract` only accepts final operation once.
+flagmap.
+
+## problem: how to retry relay-transaction of foreign_chain -> home_chain (withdrawal) relay-transaction
+
+`HomeBridgeContract` only accepts final operation once.
+
+if all preconditions are met.
+
+retryExternalTransfer(transactionHash)
+
+emits withdraw event again
+
+retry by hash
+
+transactionHash is not known on the foreign_chain.
+that is a problem since it would open up spamming the contract.
+
+## problem: what if the validator that was selected to relay the final operation dies or goes rouge
+
+the operation gets stuck.
+
+possible solution: timeout?
+add public function to retry stuck transactions on both sides.
+if its your transaction you can call it.
+call it automatically on certain conditions.
+
+alternatively: only authorities can unstuck transactions.
+
+remember sender. only sender can unstuck transactions?
+that puts the burden on the sender which is bad UX.
+
+add ability to retry relay-transactions.
+
+### retry
+
+originating chain has proof that retry is required
+
+the event is the proof since it can only be emitted by a function
+
+must stay in function state that is protected by `onlyAuthority`
+
+ForeignChain.retryDeposit(transactionHash) ->
+RetryDeposit(transactionHash, validatorSetHash)
+-> bridges ->
+ForeignChain.retryDepositConfirm(signature, transactionHash)
+
+it does not even need to get back to the other side
+it just needs to go to the validators and then back to the originating chain
+
+if retryDepositConfirm has collected enough signatures and the validatorSetHash
+is still the same then the deposit goes through
+
+now all the 
+
+**in general just calling out to the validators and collecting n signatures
+is enough proof**
+
+if the validator set differs then the new validator set is not yet on the
+HomeChain 
+different in both directions.
+
+how can we wait until the new validator set is there?
+
+use a validator set nonce instead of a hash
+
+retry until they match???
+
+hoping that in the meantime the bridges have transfered the new validator set
+from foreign to home
+
+use the delay in transport as waiting
+
+if in the meantime we are good in using both the new and old validator set
+then we can simplify it

--- a/docs/bridge_with_dynamic_validator_set_2.md
+++ b/docs/bridge_with_dynamic_validator_set_2.md
@@ -55,12 +55,40 @@ hasn't previously been on `foreign_chain` since they only pass in one direction.
 
 now if 
 
+## can we do without an actual copy of the validator set on `home_chain`?
+
+we could have `home_chain` offload all the work to foreign_bridge
+
+validators could proove a transaction as stuck.
+
+on the withdrawal we need the validator set on `home_chain` to
+verify the final transfer.
+
+## a validator set signs off on a change
+
+## accept multiple recent validator sets
+
+## we can only send if we have proof the other side has authorities
+
 ## withdrawal
 
 `foreign_chain.ForeignBridge.transfer(recipient, value)`
 emits `Withdraw(current arguments..., trustedAuthoritiesHash, validatorSet)` where
 `validatorSet = ValidatorSet.getValidators()`
 and trustedAuthoritiesHash
+
+we have to rely on the other side having a certain
+validatorSet
+
+last confirmed received validator set
+
+confirmed received = either n blocks deep or explicit confirmation.
+
+**or outside entity that somehow has proof of confirmation!!!!**
+
+set received:
+
+that we are sure has been transmitted
 
 `lastRelayedValidatorSet` and then we call that
 
@@ -80,8 +108,42 @@ this could make it stuck
 
 expire only if no newer versions
 
-## incentive to keep it up to date
+## add incentive to keep it up to date
+
+authorities can be assumed to have natural incentive to behave
 
 ## assumption: old authority still has majority of behaving
 
 ## unstucking of stuck for other reasons
+
+
+## why do we need bridge process to relay changes to validator set?
+
+otherwise the validator set on `home_bridge` will grow stale.
+
+that's not a problem for deposits.
+because the newest validator set will pick up on the `Deposit` and
+`ForeignBridge.deposit()` will only accept authorities from newest validator set.
+
+is it a problem with withdraw?
+
+**the final bridge process that calls `HomeBridge.withdraw()` must be
+trusted by `HomeBridge`**
+
+that trust relationship might change
+
+## validator processes have access to both chains
+
+they view the whole picture (except for the other validators)
+
+they also do the relay of the validator set
+
+put more logic into validator processes
+
+
+
+## relay transaction state machine across the whole system
+
+### deposit
+
+

--- a/docs/bridge_with_dynamic_validator_set_2.md
+++ b/docs/bridge_with_dynamic_validator_set_2.md
@@ -1,0 +1,87 @@
+# new possibly simpler approach to make bridge work with dynamic validator sets
+
+keep the hashes of the last validator sets
+sends validator set if hash of validator set
+
+if the last validator set 
+
+
+
+## abstract
+
+trust previous authority sets within a time window
+
+`block.number`
+
+keep hashes of trusted authority sets in `home_chain.HomeBridge`.
+expire them.
+
+all messages back and forth as well as additional message on
+validator set change contain both the hash of a previously trusted
+authority set as well as the newest authority set if it differs.
+
+transport of authority set only 
+
+transport authorities set with each message
+
+don't need any specific message relay.
+
+## starting context
+
+`HomeBridge` contract is deployed on `home_chain`
+
+the hash of the initial set of authorities is in `trustedAuthoritySetHashes`
+
+## deposit
+
+`home_chain.HomeBridge.()` is called and emits
+`Deposit(sender, value, trustedAuthoritiesHash)` where
+`trustedAuthoritiesHash = sha3(authorities)` is a new argument to `Deposit`.
+
+bridge processes pick up `Deposit` event and call
+`foreign_chain.ForeignBridge.deposit(current arguments..., trustedAuthoritiesHash)`
+
+trusted authority sets
+
+add `trustedAuthoritiesHash` to hash.
+
+check that we have `trustedAuthoritiesHash` in trusted authorities
+and that the current authority is within that set.
+
+modify `onlyAuthority`
+
+**invariant:** never any authority hash in `HomeBridge` that
+hasn't previously been on `foreign_chain` since they only pass in one direction.
+
+now if 
+
+## withdrawal
+
+`foreign_chain.ForeignBridge.transfer(recipient, value)`
+emits `Withdraw(current arguments..., trustedAuthoritiesHash, validatorSet)` where
+`validatorSet = ValidatorSet.getValidators()`
+and trustedAuthoritiesHash
+
+`lastRelayedValidatorSet` and then we call that
+
+the one final transaction
+
+what if that chosen authority goes
+
+ability to retry after really long block number increase to prevent ddos
+
+send an actual confirm back to be absolutely sure
+
+until actual confirm has been sent it is possible to retry
+
+## edge case: misbehaving authorities dont update
+
+this could make it stuck
+
+expire only if no newer versions
+
+## incentive to keep it up to date
+
+## assumption: old authority still has majority of behaving
+
+## unstucking of stuck for other reasons

--- a/docs/bridged_validator_set.md
+++ b/docs/bridged_validator_set.md
@@ -96,7 +96,7 @@ see the implementation of
 how do we prevent an older change from overwriting a newer that just
 happened to get mined later?
 
-**only accept changes in blocks that are >= to the block we last accepted a change from**
+**only accept changes in blocks that are >= the block we last accepted a change from**
 
 [see the implementation](../contracts/bridged_validator_set.sol)
 

--- a/docs/bridged_validator_set.md
+++ b/docs/bridged_validator_set.md
@@ -1,13 +1,12 @@
 # keeping a validator set on one chain in sync with a validator set on another chain
 
-in other words: how to allow contracts to access a validator set on another chain?
+allowing contracts to access a validator set on another chain
 
 ## context
 
 there are two chains named `home_chain` and `foreign_chain`.
-that naming is taken from parity-bridge.
-for this document the meaning of the names is irrelevant, meaning
-one could switch the names.
+that naming is taken from https://github.com/paritytech/parity-bridge
+for this document the special meaning of the names is irrelevant. one could switch the names.
 
 an implementation of the `ValidatorSet` contract interface is deployed to `foreign_chain`.
 the implementation could be [MajorityList](https://github.com/paritytech/contracts/blob/master/validator_contracts/MajorityList.sol) for example.
@@ -16,50 +15,58 @@ the implementation could be [MajorityList](https://github.com/paritytech/contrac
 
 each validator process has a `validator_address` and the private key for it.
 
-each validator process is connected to the `home_chain` through
+each validator process is connected to `home_chain` through
 a parity node that has that validators `validator_address` unlocked.
 
-each validator process is connected to the `foreign_chain` through
+each validator process is connected to `foreign_chain` through
 a parity node that has that validators `validator_address` unlocked.
 
 in order for the approach laid out in this document to work,
 a validator process must use/unlock the same
 address on on both `home_chain` and `foreign_chain`.
 
-shouldn't usually be a problem.
-if using the same address isn't possible for some reason then a more complicated
-approach is needed.
+that shouldn't usually be a problem.
+if using the same address isn't possible for some reason then a more complicated approach is needed.
 see [varying_home_and_foreign_addresses.md](varying_home_and_foreign_addresses.md)
-for some thoughts on that.
-
-`ValidatorSet.getValidators() == validator_address for each validator that is considered trustworthy`
+for thoughts on that.
 
 ## core problem
 
-**how do we make an always up to date version of `foreign_chain.ValidatorSet.getValidators()`
+**how do we make an always fairly recent but finalized version of `foreign_chain.ValidatorSet.getValidators()`
 available to contracts on the `home_chain`?**
+
+"fairly recent but finalized" meaning: lagging behind `foreign_chain.ValidatorSet.getValidators()` by whatever time it takes
+to be certain about finality on `foreign_chain`.
 
 ## solution space
 
 ### who stores the synced validator set on `home_chain`?
 
-the relayed validator set could be stored directly in a contract using it
-(`HomeBridge` https://github.com/paritytech/parity-bridge/blob/master/contracts/bridge.sol for example).
+the relayed validator set could be stored directly in a contract using it.
+`HomeBridge` https://github.com/paritytech/parity-bridge/blob/master/contracts/bridge.sol for example.
 
 alternatively it could be stored in a seperate `BridgedValidatorSet` contract.
-the latter solution adds one more contract but keeps concerns seperate
-(doesn't clutter `HomeBridge` with validator set relay logic) and allows
-reuse of the bridged validator set by other contracts.
-i'd prefer a dedicated contract.
+this solution adds one more contract but keeps concerns seperate.
+it doesn't clutter `HomeBridge`, or other processes using it, with validator set relay logic.
+that keeps contracts simple and makes less room for bugs.
+
+any contracts on `home_chain` could reuse the `BridgedValidatorSet`.
+
+i'd prefer a dedicated `BridgedValdiatorSet` contract for those reasons.
 
 [here's a draft for such a `BridgedValidatorSet` contract](../contracts/bridged_validator_set.sol)
 
 it requires no changes to the `ValidatorSet` deployed on `foreign_chain`!
 
+goal is that most of the time:
+`foreign_bridge.ValidatorSet.getValidators() == home_bridge.BridgedValidatorSet.getValidators()`
+except when `foreign_bridge.ValidatorSet.getValidators()`
+changed and is not yet finalized.
+
 ### what triggers a relay of validator set changes?
 
-it would be a clean solution to have validator processes listen to `ChangeFinalized`
-events (see https://github.com/paritytech/contracts/blob/master/validator_contracts/MajorityList.sol).
+a simple solution is to have validator processes listen to `ChangeFinalized`
+events. see https://github.com/paritytech/contracts/blob/master/validator_contracts/MajorityList.sol.
 
 `ChangeFinalized` currently (2017-11-14) doesn't exist in the `ValidatorSet` interface: https://github.com/paritytech/contracts/blob/111fe5c4ce1ddd10a0f1a68a02602697676a6ff7/validator_contracts/MajorityList.sol#L3
 
@@ -75,7 +82,7 @@ since `old_validator_set` is the only thing the `BridgedValidatorSet` contract t
 in time.
 
 this should not be a problem if we are sure we can still trust the majority
-of `old_validator_set` in the minutes following a change to the validator set.
+of `old_validator_set` in the time it takes to fully relay (finalized) the validator set to `home_chain`.
 
 ### how does the relay happen?
 
@@ -87,9 +94,24 @@ where `blockNumber` is the number of the block containing the `ChangeFinalized` 
 see the implementation of
 [calledByValidatorProcessOnChangeFinalizedEvent](../contracts/bridged_validator_set.sol).
 
+### how do we ensure that only validator set changes that are final on `foreign_chain` get relayed?
+
+this is crucial!
+
+validator processes could only do the relay for `ChangeFinalized` events
+in blocks that have n (20 for example) confirmations.
+
+alternatively validator processes could reach out to some entity providing
+finality information
+(rob mentioned that).
+
 ### how do we change the `requiredSignatureCount` in `BridgedValidatorSet`?
 
-*future work*
+along the lines of:
+having `old_required_signature_count` validator processes
+sign off on the change and modifying contract to work with non-constant `requiredSignatureCount`.
+
+*easy future work*
 
 ### what happens if two transactions containing `ChangeFinalized` get mined in reverse order?
 
@@ -99,6 +121,10 @@ happened to get mined later?
 **only accept changes in blocks that are >= the block we last accepted a change from**
 
 [see the implementation](../contracts/bridged_validator_set.sol)
+
+alternatively a nonce could be used. that would require modification of
+`foreign_chain.ValidatorSet` though. loosing the nice property of not having to touch that
+contract for the validator set bridge to work.
 
 ### what if a rogue validator tampers with the `newValidatorSet` in transit?
 
@@ -112,9 +138,16 @@ with the exact same pair of `newValidatorSet` and `blockNumber`.
 
 ### what if one of the transactions containing call to `calledByValidatorProcessOnChangeFinalizedEvent` never gets mined on `home_chain`?
 
-change might not be relayed in that case
+change might never get relayed in that case.
+then until the next change (might take a very long time):
+`foreign_bridge.ValidatorSet.getValidators() != home_bridge.BridgedValidatorSet.getValidators()`
 
-add some retry functionality into validator processes
+other bridging systems that depend on `foreign_chain.ValidatorSet` and `home_chain.BridgedValidatorSet`
+will usually check that the validator set hasn't changed during their
+own bridging process. such systems would be stuck while
+`foreign_bridge.ValidatorSet.getValidators() != home_bridge.BridgedValidatorSet.getValidators()`
+
+we have to add some retry functionality into validator processes!
 
 *future work*
 

--- a/docs/bridged_validator_set.md
+++ b/docs/bridged_validator_set.md
@@ -1,0 +1,267 @@
+# keeping a validator set on one chain in sync with a validator set on another chain
+
+allow contracts to access a validator set on another chain
+
+## context
+
+there are two chains `home_chain` and `foreign_chain`.
+
+a `ValidatorSet` contract is deployed to `foreign_chain`.
+for example: https://github.com/paritytech/contracts/blob/master/validator_contracts/MajorityList.sol.
+
+n validator processes are running.
+each validator process is connected to a parity node that is
+connected to both 
+those addresses are `ValidatorSet.getValidators()`
+
+each validator process has a 
+
+each validator process is connected to the `home_chain` through
+a parity node that has that validators `validator_address` unlocked.
+
+each validator process is connected to the `foreign_chain` through
+a parity node that has that validators `validator_address` unlocked.
+
+in order for the approach laid out in this document to work
+a validator process must use/unlock the same
+address on on both `home_chain` and `foreign_chain`.
+
+that shouldn't be a problem usually.
+if that isn't possible for some reason then a more complicated
+
+thoughts on implementing 
+[varying_home_and_foreign_addresses.md]
+
+`ValidatorSet.getValidators() == validator_address for each validator`
+
+[here]() are some thoughts on
+we assume that 
+
+that is more complicated though
+
+the 
+
+the addresses on the home and foreign chain are different
+
+each bridge process 
+connected and has the validator account unlocked.
+node that is connected to the foreign_chain
+
+**how do we make an always up to date version of `foreign_chain.ValidatorSet.getValidators()`
+available to contracts on the `home_chain`?**
+
+## who stores the synced validator set on `home_chain`?
+
+the relayed validator set could be stored directly in a contract using it
+(`HomeBridge` https://github.com/paritytech/parity-bridge/blob/master/contracts/bridge.sol for example).
+alternatively it could be stored in a seperate `SyncedValidatorSet` contract
+(alternative names: `ValidatorSetBridge`, `BridgedValdiatorSet`, ...).
+the latter solution adds one more contract but keeps concerns seperate
+(doesn't clutter `HomeBridge` with validator set relay logic) and allows
+reuse of the bridged validator set by other contracts.
+i'd prefer a dedicated contract.
+
+here's a draft for such a `BridgedValidatorSet` contract:
+https://gist.github.com/snd/c3c9dba3b7f80678a09e1320697911b1
+
+it requires no changes to the `ValidatorSet` deployed on `foreign_chain`.
+
+### the addresses of the validator set on foreign and home are different
+
+only the bridge-validator processes know both addresses.
+
+together with the validatorSet each bridge validator also sends its address on
+`calledByBridgeOnChangeFinalizedEvent`
+
+not that easy since we'd only get the addresses of the validators that
+have signed off on the change.
+
+the
+
+
+change to a new validator set can only happen if the whole validator set
+is able to relay the change.
+
+or should we modify the validator set contract on the foreign_chain?
+special validator set contract that makes bridging easier
+
+### what triggers a relay of validator set changes?
+
+it would be a clean solution to have validator processes listen to `ChangeFinalized`
+events (see https://github.com/paritytech/contracts/blob/master/validator_contracts/MajorityList.sol).
+
+`ChangeFinalized` currently (2017-11-14) doesn't exist in the `ValidatorSet` interface (https://github.com/paritytech/contracts/blob/111fe5c4ce1ddd10a0f1a68a02602697676a6ff7/validator_contracts/MajorityList.sol#L3 (https://github.com/paritytech/contracts/blob/111fe5c4ce1ddd10a0f1a68a02602697676a6ff7/validator_contracts/MajorityList.sol#L3).
+it only exists in the implementations https://github.com/paritytech/contracts/blob/111fe5c4ce1ddd10a0f1a68a02602697676a6ff7/validator_contracts/MajorityList.sol#L22.
+it should probably get moved into `ValidatorSet`.
+
+### who relays the validator set?
+
+if the validator set on `foreign_chain` has changed from `old_validator_set`
+to `new_validator_set` we
+still have to rely on `old_validator_set` to relay the changes
+since `old_validator_set` is the only thing `SyncedValidatorSet` contract trusts at that point
+in time.
+
+this should not be a problem if we are sure we can still trust the majority
+of the old validator set in the minutes following a change to the validator set.
+
+### how does the relay happen?
+
+each bridge process responds to `ChangeFinalized(addresses)`
+events on the `foreign_chain.ValidatorSet` contract
+by calling `home_chain.SyncedValidatorSet.calledByBridgeOnChangeFinalized(addresses)`.
+
+see the implementation of `SyncedValidatorSet.calledByBridgeOnChangeFinalized`
+above for further details.
+
+### syncing required signatures
+
+it might be required to change requiredSignatures
+
+### what happens out of order
+
+nonce ensures that validator set never gets overwritten
+by previous version because of 
+
+## edge cases
+
+### what if a rogue validator tampers with the validatorSet in transit
+
+prevented by hash
+only if 
+
+checks the integrity of the actually transmitted validator set
+
+only switch to new validator set if requiredSignatures from old validator set
+with identical validator set and nonce and nonce > lastCommitedNonce
+
+
+### what if a rogue validator is the last one to and the hash
+
+### what if transaction never gets mined
+
+### garbage collection
+
+### transaction order
+
+the transaction
+
+the second change gets more signatures later
+
+one could introduce a nonce
+
+nonce
+
+TODO flesh out this section
+
+----
+
+a change we could make is to only have validators that are both in the old and new
+validator set sign off on the 
+
+but that would leave open the possibility of some subset of validators
+colluding and 
+
+`ForeignBridgeContract` can check it as well
+
+`ForeignBridgeContract` and the validators working together
+can we make it that the 
+
+need to use both initialize change and commit change
+
+### possible solution 2
+
+make `foreign_chain` refresh validator set on every action
+and if it has changed make it update its internal validator set
+and make it initialize the relay to `home_chain`
+through an event that is listened to by the old and new validators.
+
+in what order to change validator set:
+
+start bridge process for new validators.
+change validator set.
+have the change get picked up by the new validator set.
+
+the relay must be consistent
+
+the only information about authority that the `HomeBridgeContract` has
+is the old validator set.
+
+have the old validator set cooperate to relay changes to itself.
+sounds risky.
+
+we trusted the old validator set.
+we still mostly trust it.
+
+`HomeBridgeContract` only trusts n signatures of it's current validator set.
+that means only n signatures of its current validator set can convince it to trust
+something else.
+
+without using that piece of information a set of fake validators
+could fabricate requests to HomeBridge and take over as validators.
+they could only take over on HomeBridge and not ForeignBridge.
+so relay-transactions would still fail since the sets would not match up.
+but they could DOS the bridge.
+
+**question: is this correct and safe?**
+
+
+## assumptions and definitions
+
+`relay-transaction` means a transaction from one chain to another chain.
+(*question: how do you call that?*)
+
+`in-flight` means beginning when 
+and ending when the 
+
+with 
+
+```
+HomeBridgeContract.()
+-> Deposit event
+1->* bridges
+n->1 ForeignBridgeContract.deposit()
+```
+
+and `ForeignBridgeContract.deposit` is the final transaction.
+but only if n signatures were collected.
+
+`home_chain` is an ethereum blockchain.
+
+`foreign_chain` is an ethereum blockchain.
+
+`ValidatorSetContract` ([MajorityList](https://github.com/paritytech/contracts/blob/master/validator_contracts/MajorityList.sol)) is deployed to `foreign_chain`.
+`ForeignBridgeContract` is deployed to `foreign_chain`.
+
+`HomeBridgeContract` is deployed to `home_chain`.
+
+n bridge processes are running:
+
+each bridge process represents an authority / a validator with a signing key
+
+each bridge process is connected to a parity node that is
+connected and has the validator account unlocked.
+node that is connected to the foreign_chain
+
+the addresses are in the validator set.
+
+it starts out with the vali
+
+## problem: how to relay changes to foreign_chain.ValidatorSetContract.validatorsList to home_chain.HomeBridge and foreign_chain.ForeignBridge
+
+make bridges listen for `ValidatorSet.ChangeFinalized` events on the
+foreign_chain.
+
+there is the slight problem that
+
+if `ValidatorSet.ChangeFinalized` occurs the old-bridges all send the new validator
+set to `ForeignChainContract` and `HomeChainContract`.
+
+## invariants
+
+the only authority that HomeBridgeContract and ForeignBridgeContract
+are aware of is their current set of authority addresses.
+
+
+that the majority of the old validator set is still
+

--- a/docs/bridged_validator_set.md
+++ b/docs/bridged_validator_set.md
@@ -78,12 +78,13 @@ of `old_validator_set` in the minutes following a change to the validator set.
 
 ### how does the relay happen?
 
-each bridge process responds to `ChangeFinalized(addresses)`
+each validator process responds to `ChangeFinalized(addresses)`
 events on the `foreign_chain.ValidatorSet` contract
-by calling `home_chain.SyncedValidatorSet.calledByBridgeOnChangeFinalized(addresses)`.
+by calling `home_chain.BridgedValidatorSet.calledByValidatorProcessOnChangeFinalized(addresses, blockNumber)`
+where `blockNumber` is the number of the block containing the `ChangeFinalized` event.
 
-see the implementation of `SyncedValidatorSet.calledByBridgeOnChangeFinalized`
-above for further details.
+see the implementation of
+[calledByValidatorProcessOnChangeFinalizedEvent](../contracts/bridged_validator_set.sol).
 
 ### how do we change the `requiredSignatureCount` in `BridgedValidatorSet`?
 

--- a/docs/bridged_validator_set.md
+++ b/docs/bridged_validator_set.md
@@ -55,25 +55,6 @@ i'd prefer a dedicated contract.
 
 it requires no changes to the `ValidatorSet` deployed on `foreign_chain`!
 
-### the addresses of the validator set on foreign and home are different
-
-only the bridge-validator processes know both addresses.
-
-together with the validatorSet each bridge validator also sends its address on
-`calledByBridgeOnChangeFinalizedEvent`
-
-not that easy since we'd only get the addresses of the validators that
-have signed off on the change.
-
-the
-
-
-change to a new validator set can only happen if the whole validator set
-is able to relay the change.
-
-or should we modify the validator set contract on the foreign_chain?
-special validator set contract that makes bridging easier
-
 ### what triggers a relay of validator set changes?
 
 it would be a clean solution to have validator processes listen to `ChangeFinalized`

--- a/docs/bridged_validator_set.md
+++ b/docs/bridged_validator_set.md
@@ -51,7 +51,7 @@ the latter solution adds one more contract but keeps concerns seperate
 reuse of the bridged validator set by other contracts.
 i'd prefer a dedicated contract.
 
-[here's a draft for such a `BridgedValidatorSet` contract](./contracts/bridged_validator_set.sol)
+[here's a draft for such a `BridgedValidatorSet` contract](../contracts/bridged_validator_set.sol)
 
 it requires no changes to the `ValidatorSet` deployed on `foreign_chain`!
 

--- a/docs/bridged_validator_set.md
+++ b/docs/bridged_validator_set.md
@@ -1,17 +1,15 @@
 # keeping a validator set on one chain in sync with a validator set on another chain
 
-allow contracts to access a validator set on another chain
+in other words: how to allow contracts to access a validator set on another chain?
 
 ## context
 
 there are two chains `home_chain` and `foreign_chain`.
-the names are just to distinguish the chains and have no special meaning.
+the names are just to distinguish the chains below and have no special meaning
+for now.
 
 an implementation of the `ValidatorSet` contract interface is deployed to `foreign_chain`.
 the implementation could be [MajorityList](https://github.com/paritytech/contracts/blob/master/validator_contracts/MajorityList.sol) for example.
-
-why is it deployed to the `foreign_chain`?
-well it can only be deployed to one chain
 
 `n` validator processes are running.
 
@@ -23,7 +21,7 @@ a parity node that has that validators `validator_address` unlocked.
 each validator process is connected to the `foreign_chain` through
 a parity node that has that validators `validator_address` unlocked.
 
-in order for the approach laid out in this document to work
+in order for the approach laid out in this document to work,
 a validator process must use/unlock the same
 address on on both `home_chain` and `foreign_chain`.
 

--- a/docs/bridged_validator_set.md
+++ b/docs/bridged_validator_set.md
@@ -4,9 +4,10 @@ in other words: how to allow contracts to access a validator set on another chai
 
 ## context
 
-there are two chains `home_chain` and `foreign_chain`.
-the names are just to distinguish the chains below and have no special meaning
-for now.
+there are two chains named `home_chain` and `foreign_chain`.
+that naming is taken from parity-bridge.
+for this document the meaning of the names is irrelevant, meaning
+one could switch the names.
 
 an implementation of the `ValidatorSet` contract interface is deployed to `foreign_chain`.
 the implementation could be [MajorityList](https://github.com/paritytech/contracts/blob/master/validator_contracts/MajorityList.sol) for example.

--- a/docs/bridged_validator_set.md
+++ b/docs/bridged_validator_set.md
@@ -90,150 +90,33 @@ see the implementation of
 
 *future work*
 
-### what happens out of order
+### what happens if two transactions containing `ChangeFinalized` get mined in reverse order?
 
-nonce ensures that validator set never gets overwritten
-by previous version because of 
+how do we prevent an older change from overwriting a newer that just
+happened to get mined later?
 
-## edge cases
+**only accept changes in blocks that are >= to the block we last accepted a change from**
 
-### what if a rogue validator tampers with the validatorSet in transit
+[see the implementation](../contracts/bridged_validator_set.sol)
 
-prevented by hash
-only if 
+### what if a rogue validator tampers with the `newValidatorSet` in transit?
 
-checks the integrity of the actually transmitted validator set
+**prevented by hashing the validator set**
 
-only switch to new validator set if requiredSignatures from old validator set
-with identical validator set and nonce and nonce > lastCommitedNonce
+only switch to new validator set if `requiredSignaturesCount`
+validators from old validator set called `calledByValidatorProcessOnChangeFinalizedEvent`
+with the exact same pair of `newValidatorSet` and `blockNumber`.
 
+[see the implementation](../contracts/bridged_validator_set.sol)
 
-### what if a rogue validator is the last one to and the hash
+### what if one of the transactions containing call to `calledByValidatorProcessOnChangeFinalizedEvent` never gets mined on `home_chain`?
 
-### what if transaction never gets mined
+change might not be relayed in that case
 
-### garbage collection
+add some retry functionality into validator processes
 
-### transaction order
+*future work*
 
-the transaction
+### how do we prevent storage of `BridgedValidatorSet` from infinitely expanding?
 
-the second change gets more signatures later
-
-one could introduce a nonce
-
-nonce
-
-TODO flesh out this section
-
-----
-
-a change we could make is to only have validators that are both in the old and new
-validator set sign off on the 
-
-but that would leave open the possibility of some subset of validators
-colluding and 
-
-`ForeignBridgeContract` can check it as well
-
-`ForeignBridgeContract` and the validators working together
-can we make it that the 
-
-need to use both initialize change and commit change
-
-### possible solution 2
-
-make `foreign_chain` refresh validator set on every action
-and if it has changed make it update its internal validator set
-and make it initialize the relay to `home_chain`
-through an event that is listened to by the old and new validators.
-
-in what order to change validator set:
-
-start bridge process for new validators.
-change validator set.
-have the change get picked up by the new validator set.
-
-the relay must be consistent
-
-the only information about authority that the `HomeBridgeContract` has
-is the old validator set.
-
-have the old validator set cooperate to relay changes to itself.
-sounds risky.
-
-we trusted the old validator set.
-we still mostly trust it.
-
-`HomeBridgeContract` only trusts n signatures of it's current validator set.
-that means only n signatures of its current validator set can convince it to trust
-something else.
-
-without using that piece of information a set of fake validators
-could fabricate requests to HomeBridge and take over as validators.
-they could only take over on HomeBridge and not ForeignBridge.
-so relay-transactions would still fail since the sets would not match up.
-but they could DOS the bridge.
-
-**question: is this correct and safe?**
-
-
-## assumptions and definitions
-
-`relay-transaction` means a transaction from one chain to another chain.
-(*question: how do you call that?*)
-
-`in-flight` means beginning when 
-and ending when the 
-
-with 
-
-```
-HomeBridgeContract.()
--> Deposit event
-1->* bridges
-n->1 ForeignBridgeContract.deposit()
-```
-
-and `ForeignBridgeContract.deposit` is the final transaction.
-but only if n signatures were collected.
-
-`home_chain` is an ethereum blockchain.
-
-`foreign_chain` is an ethereum blockchain.
-
-`ValidatorSetContract` ([MajorityList](https://github.com/paritytech/contracts/blob/master/validator_contracts/MajorityList.sol)) is deployed to `foreign_chain`.
-`ForeignBridgeContract` is deployed to `foreign_chain`.
-
-`HomeBridgeContract` is deployed to `home_chain`.
-
-n bridge processes are running:
-
-each bridge process represents an authority / a validator with a signing key
-
-each bridge process is connected to a parity node that is
-connected and has the validator account unlocked.
-node that is connected to the foreign_chain
-
-the addresses are in the validator set.
-
-it starts out with the vali
-
-## problem: how to relay changes to foreign_chain.ValidatorSetContract.validatorsList to home_chain.HomeBridge and foreign_chain.ForeignBridge
-
-make bridges listen for `ValidatorSet.ChangeFinalized` events on the
-foreign_chain.
-
-there is the slight problem that
-
-if `ValidatorSet.ChangeFinalized` occurs the old-bridges all send the new validator
-set to `ForeignChainContract` and `HomeChainContract`.
-
-## invariants
-
-the only authority that HomeBridgeContract and ForeignBridgeContract
-are aware of is their current set of authority addresses.
-
-
-that the majority of the old validator set is still
-
+*future work*

--- a/docs/bridged_validator_set.md
+++ b/docs/bridged_validator_set.md
@@ -60,8 +60,9 @@ it requires no changes to the `ValidatorSet` deployed on `foreign_chain`!
 it would be a clean solution to have validator processes listen to `ChangeFinalized`
 events (see https://github.com/paritytech/contracts/blob/master/validator_contracts/MajorityList.sol).
 
-`ChangeFinalized` currently (2017-11-14) doesn't exist in the `ValidatorSet` interface (https://github.com/paritytech/contracts/blob/111fe5c4ce1ddd10a0f1a68a02602697676a6ff7/validator_contracts/MajorityList.sol#L3 (https://github.com/paritytech/contracts/blob/111fe5c4ce1ddd10a0f1a68a02602697676a6ff7/validator_contracts/MajorityList.sol#L3).
-it only exists in the implementations https://github.com/paritytech/contracts/blob/111fe5c4ce1ddd10a0f1a68a02602697676a6ff7/validator_contracts/MajorityList.sol#L22.
+`ChangeFinalized` currently (2017-11-14) doesn't exist in the `ValidatorSet` interface: https://github.com/paritytech/contracts/blob/111fe5c4ce1ddd10a0f1a68a02602697676a6ff7/validator_contracts/MajorityList.sol#L3
+
+it only exists in the implementations: https://github.com/paritytech/contracts/blob/111fe5c4ce1ddd10a0f1a68a02602697676a6ff7/validator_contracts/MajorityList.sol#L22.
 it should probably get moved into `ValidatorSet`.
 
 ### who relays the validator set?
@@ -69,11 +70,11 @@ it should probably get moved into `ValidatorSet`.
 if the validator set on `foreign_chain` has changed from `old_validator_set`
 to `new_validator_set` we
 still have to rely on `old_validator_set` to relay the changes
-since `old_validator_set` is the only thing `SyncedValidatorSet` contract trusts at that point
+since `old_validator_set` is the only thing the `BridgedValidatorSet` contract trusts at that point
 in time.
 
 this should not be a problem if we are sure we can still trust the majority
-of the old validator set in the minutes following a change to the validator set.
+of `old_validator_set` in the minutes following a change to the validator set.
 
 ### how does the relay happen?
 
@@ -84,9 +85,9 @@ by calling `home_chain.SyncedValidatorSet.calledByBridgeOnChangeFinalized(addres
 see the implementation of `SyncedValidatorSet.calledByBridgeOnChangeFinalized`
 above for further details.
 
-### syncing required signatures
+### how do we change the `requiredSignatureCount` in `BridgedValidatorSet`?
 
-it might be required to change requiredSignatures
+*future work*
 
 ### what happens out of order
 

--- a/docs/varying_home_and_foreign_addresses.md
+++ b/docs/varying_home_and_foreign_addresses.md
@@ -1,0 +1,95 @@
+# problem
+
+for each validator `home_address != foreign_address` or in other words
+`home_address_set != foreign_address_set`.
+
+this means we can't simply relay `foreign_address_set`
+as described in
+https://gist.github.com/snd/c3c9dba3b7f80678a09e1320697911b1
+since it will be of no use 
+
+
+
+# solution space
+
+only a validator process knows both its `home_address` and its `foreign_address`.
+
+## approach 1 (won't work)
+
+together with the validatorSet each validator also sends its address on
+`calledByBridgeOnChangeFinalizedEvent`.
+
+`BridgedValidatorSet` collects the `home_address` and once enough
+validators
+
+this won't work because it will 
+
+which leads to
+
+## approach 2 (won't work)
+
+we need all the new validators to relay the change
+
+problem: a single rogue validator in the new set can block the entire change
+
+### what if the validators don't relay the change
+
+the SyncedValidatorSet will continue to 
+
+
+
+that will cause problems
+
+all relay transactions will be stuck
+
+**is this acceptable?**
+
+
+## approach 3 (needs more work)
+
+a bridge-validator uses two addresses (one on each chain).
+
+use a modified version of `ValidatorSet` that works on pairs of addresses.
+
+or more generally allow adding additional information to
+each validator.
+
+## approach 4 (needs more work)
+
+have another set of validators
+
+that set is responsible for relaying changes to another validator set
+from chain to chain.
+
+chicken and egg problem.
+
+can we do all the signing off on one chain?
+
+and then actually do the relay
+
+we trust 
+
+
+who trusts who
+
+
+`HomeBridge`
+
+
+taking a step back. what do we want to accomplish.
+
+place something on home_chain that is not trusted by
+
+## approach
+
+is there some previous work on relaying validator sets?
+
+is this actually worth digging into
+
+---
+
+self relaying validator set
+
+can we split the validator 
+
+a validator set that can relay its changes to another chain


### PR DESCRIPTION
thought i'd do this as a branch on the relevant repo. seems cleaner than a bunch of gists

ready for review/feedback:
https://github.com/paritytech/parity-bridge/blob/validator_set_thoughts/docs/bridged_validator_set.md

writeup in progress:
https://github.com/paritytech/parity-bridge/blob/validator_set_thoughts/docs/bridge_with_dynamic_validator_set.md

feedback and questions are greatly appreciated :)