### PR TITLE
Add gas price option in config example

### DIFF
--- a/examples/config.toml
+++ b/examples/config.toml
@@ -25,8 +25,12 @@ accounts = [
 required_signatures = 1
 
 [transactions]
-home_deploy = { gas = 1000000 }
-foreign_deploy = { gas = 3000000 }
-deposit_relay = { gas = 150000 }
-withdraw_relay = { gas = 100000 }
-withdraw_confirm = { gas = 300000 }
+# these happen on `home`:
+home_deploy = { gas = 1000000 , gas_price = 0 }
+withdraw_relay = { gas = 200000 , gas_price = 0 }
+
+# these happen on `foreign`:
+foreign_deploy = { gas = 3000000 , gas_price = 0 }
+deposit_relay = { gas = 150000 , gas_price = 0 }
+
+withdraw_confirm = { gas = 300000 , gas_price = 0 }


### PR DESCRIPTION
These options are there in https://github.com/paritytech/parity-bridge/blob/master/integration-tests/bridge_config.toml and sometimes it is intuitive to look into example to find these config files.