### PR TITLE
Add error message when contract binary can not be opened

### DIFF
--- a/bridge/src/config.rs
+++ b/bridge/src/config.rs
@@ -75,7 +75,12 @@ impl Node {
             contract: ContractConfig {
                 bin: {
                     let mut read = String::new();
-                    let mut file = fs::File::open(node.contract.bin)?;
+                    let mut file = fs::File::open(&node.contract.bin).chain_err(|| {
+                        format!(
+                            "Cannot open compiled contract file at {}",
+                            node.contract.bin.to_string_lossy()
+                        )
+                    })?;
                     file.read_to_string(&mut read)?;
                     Bytes(read.from_hex()?)
                 },


### PR DESCRIPTION
I spent a bit too long trying to figure out why I was getting the error `No such file or directory (os error 2)`. 

I've added a simple error message, similar to how the other file open error is handled.