### PR TITLE
Fixed side_contract address pointing to main_contract address

### DIFF
--- a/bridge/src/side_contract.rs
+++ b/bridge/src/side_contract.rs
@@ -48,7 +48,7 @@ impl<T: Transport> SideContract<T> {
     pub fn new(transport: T, config: &Config, state: &State) -> Self {
         Self {
             transport,
-            contract_address: state.main_contract_address,
+            contract_address: state.side_contract_address,
             authority_address: config.address,
             required_signatures: config.authorities.required_signatures,
             request_timeout: config.side.request_timeout,


### PR DESCRIPTION
Fixing a typo/bug which caused pointing all the side contract calls to the main contract address.