### PR TITLE
fixed bridge deployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,7 +1440,7 @@ dependencies = [
 [[package]]
 name = "web3"
 version = "0.4.0"
-source = "git+https://github.com/tomusdrw/rust-web3#37d0cb422edeae7f64184346854e5b7587ae85b1"
+source = "git+https://github.com/tomusdrw/rust-web3#6958c6107246b0fa6cfcb8356e099622889b7802"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/bridge/src/block_number_stream.rs
+++ b/bridge/src/block_number_stream.rs
@@ -138,7 +138,7 @@ mod tests {
 
         let block_number_stream = BlockNumberStream::new(BlockNumberStreamOptions {
             request_timeout: Duration::from_secs(1),
-            poll_interval: Duration::from_secs(1),
+            poll_interval: Duration::from_secs(0),
             confirmations: 12,
             transport: transport.clone(),
             after: 3,

--- a/bridge/src/block_number_stream.rs
+++ b/bridge/src/block_number_stream.rs
@@ -39,7 +39,7 @@ pub struct BlockNumberStreamOptions<T> {
     pub after: u64,
 }
 
-/// `Stream` that repeately polls `eth_blockNumber` and yields new block numbers.
+/// `Stream` that repeatedly polls `eth_blockNumber` and yields new block numbers.
 pub struct BlockNumberStream<T: Transport> {
     request_timeout: Duration,
     confirmations: u32,

--- a/bridge/src/block_number_stream.rs
+++ b/bridge/src/block_number_stream.rs
@@ -1,0 +1,119 @@
+// Copyright 2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity-Bridge.
+
+// Parity-Bridge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity-Bridge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity-Bridge.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::time::Duration;
+use error::{self, ResultExt};
+use tokio_timer::{Interval, Timeout, Timer};
+use futures::future::FromErr;
+use futures::{Async, Future, Poll, Stream};
+use web3;
+use web3::api::Namespace;
+use web3::Transport;
+use web3::helpers::CallFuture;
+use web3::types::U256;
+
+/// Block Number Stream state.
+enum State<T: Transport> {
+    AwaitInterval,
+    AwaitBlockNumber(Timeout<FromErr<CallFuture<U256, T::Out>, error::Error>>),
+}
+
+pub struct BlockNumberStreamOptions<T> {
+    pub request_timeout: Duration,
+    pub poll_interval: Duration,
+    pub confirmations: u32,
+    pub transport: T,
+    pub after: u64,
+}
+
+/// `Stream` that repeately polls `eth_blockNumber` and yields new block numbers.
+pub struct BlockNumberStream<T: Transport> {
+    request_timeout: Duration,
+    confirmations: u32,
+    transport: T,
+    last_checked_block: u64,
+    timer: Timer,
+    poll_interval: Interval,
+    state: State<T>,
+}
+
+impl<T: Transport> BlockNumberStream<T> {
+    pub fn new(options: BlockNumberStreamOptions<T>) -> Self {
+        let timer = Timer::default();
+
+        BlockNumberStream {
+            request_timeout: options.request_timeout,
+            confirmations: options.confirmations,
+            poll_interval: timer.interval(options.poll_interval),
+            transport: options.transport,
+            last_checked_block: options.after,
+            timer,
+            state: State::AwaitInterval,
+        }
+    }
+}
+
+impl<T: Transport> Stream for BlockNumberStream<T> {
+    type Item = u64;
+    type Error = error::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        loop {
+            let (next_state, value_to_yield) = match self.state {
+                State::AwaitInterval => {
+                    // wait until `interval` has passed
+                    let _ = try_stream!(self.poll_interval.poll().chain_err(|| format!(
+                        "BlockNumberStream polling interval failed",
+                    )));
+                    info!("BlockNumberStream polling last block number");
+                    let future = web3::api::Eth::new(&self.transport).block_number();
+                    let next_state = State::AwaitBlockNumber(
+                        self.timer.timeout(future.from_err(), self.request_timeout),
+                    );
+                    (next_state, None)
+                }
+                State::AwaitBlockNumber(ref mut future) => {
+                    let last_block = try_ready!(
+                        future
+                            .poll()
+                            .chain_err(|| "BlockNumberStream: fetching of last block number failed")
+                    ).as_u64();
+                    info!("BlockNumberStream: fetched last block number {}", last_block);
+                    // subtraction that saturates at zero
+                    let last_confirmed_block = last_block.saturating_sub(self.confirmations as u64);
+
+                    if self.last_checked_block < last_confirmed_block {
+                        (State::AwaitInterval, Some(last_block))
+                    } else {
+                        info!("BlockNumberStream: no blocks confirmed since we last checked. waiting some more");
+                        (State::AwaitInterval, None)
+                    }
+                }
+            };
+
+            self.state = next_state;
+
+            if value_to_yield.is_some() {
+                return Ok(Async::Ready(value_to_yield));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+}

--- a/bridge/src/database.rs
+++ b/bridge/src/database.rs
@@ -50,6 +50,14 @@ impl State {
         main_contract_deployment_receipt: &TransactionReceipt,
         side_contract_deployment_receipt: &TransactionReceipt,
     ) -> Self {
+        let main_block_number = main_contract_deployment_receipt.block_number
+            .expect("main contract creation receipt must have a block number; qed")
+            .as_u64();
+
+        let side_block_number = side_contract_deployment_receipt.block_number
+            .expect("main contract creation receipt must have a block number; qed")
+            .as_u64();
+
         Self {
             main_contract_address: main_contract_deployment_receipt
                 .contract_address
@@ -57,13 +65,11 @@ impl State {
             side_contract_address: side_contract_deployment_receipt
                 .contract_address
                 .expect("side contract creation receipt must have an address; qed"),
-            main_deployed_at_block: main_contract_deployment_receipt.block_number.as_u64(),
-            side_deployed_at_block: side_contract_deployment_receipt.block_number.as_u64(),
-            last_main_to_side_sign_at_block: main_contract_deployment_receipt.block_number.as_u64(),
-            last_side_to_main_sign_at_block: side_contract_deployment_receipt.block_number.as_u64(),
-            last_side_to_main_signatures_at_block: side_contract_deployment_receipt
-                .block_number
-                .as_u64(),
+            main_deployed_at_block: main_block_number,
+            side_deployed_at_block: side_block_number,
+            last_main_to_side_sign_at_block: main_block_number,
+            last_side_to_main_sign_at_block: side_block_number,
+            last_side_to_main_signatures_at_block: side_block_number,
         }
     }
 }

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -93,6 +93,7 @@ mod macros;
 #[macro_use]
 mod test;
 
+mod block_number_stream;
 mod bridge;
 pub use bridge::Bridge;
 pub mod config;

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -109,6 +109,7 @@ mod main_to_side_sign;
 pub use main_to_side_sign::MainToSideSign;
 mod relay_stream;
 pub use relay_stream::RelayStream;
+mod send_tx_with_receipt;
 mod side_contract;
 pub use side_contract::SideContract;
 mod side_to_main_sign;

--- a/bridge/src/log_stream.rs
+++ b/bridge/src/log_stream.rs
@@ -13,6 +13,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with Parity-Bridge.  If not, see <http://www.gnu.org/licenses/>.
+
 use error::{self, ResultExt};
 use ethabi;
 use futures::future::FromErr;

--- a/bridge/src/send_tx_with_receipt.rs
+++ b/bridge/src/send_tx_with_receipt.rs
@@ -1,0 +1,368 @@
+// Copyright 2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity-Bridge.
+
+// Parity-Bridge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity-Bridge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity-Bridge.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::time::Duration;
+use futures::future::FromErr;
+use futures::{Future, Poll};
+use tokio_timer::{Timeout, Timer};
+use web3::{self, Transport};
+use web3::types::{TransactionRequest, TransactionReceipt, U256};
+use web3::helpers::CallFuture;
+use web3::api::Namespace;
+use error::{self, ResultExt};
+
+mod inner {
+    use std::time::Duration;
+    use futures::future::FromErr;
+    use futures::{Async, Future, Poll, Stream};
+    use tokio_timer::{Timeout, Timer};
+    use web3::{self, Transport};
+    use web3::api::Namespace;
+    use web3::helpers::CallFuture;
+    use web3::types::{TransactionRequest, TransactionReceipt, H256};
+    use error::{self, ResultExt};
+    use block_number_stream::{BlockNumberStreamOptions, BlockNumberStream};
+
+    enum State<T: Transport> {
+        AwaitSendTransaction(Timeout<FromErr<CallFuture<H256, T::Out>, error::Error>>),
+        AwaitBlockNumber(H256),
+        AwaitTransactionReceipt {
+            future: Timeout<FromErr<CallFuture<Option<TransactionReceipt>, T::Out>, error::Error>>,
+            transaction_hash: H256,
+            last_block: u64,
+        }
+    }
+
+    pub struct SendTransactionWithReceiptOptions<T: Transport> {
+        pub transport: T,
+        pub request_timeout: Duration,
+        pub poll_interval: Duration,
+        pub confirmations: u32,
+        pub transaction: TransactionRequest,
+        pub after: u64,
+    }
+
+    pub struct SendTransactionWithReceipt<T: Transport> {
+        transport: T,
+        state: State<T>,
+        block_number_stream: BlockNumberStream<T>,
+        request_timeout: Duration,
+        timer: Timer,
+    }
+
+    impl<T: Transport> SendTransactionWithReceipt<T> {
+        pub fn new(options: SendTransactionWithReceiptOptions<T>) -> Self {
+            let timer = Timer::default();
+
+            let block_number_stream_options = BlockNumberStreamOptions {
+                request_timeout: options.request_timeout,
+                poll_interval: options.poll_interval,
+                confirmations: options.confirmations,
+                transport: options.transport.clone(),
+                after: options.after,
+            };
+            let block_number_stream = BlockNumberStream::new(block_number_stream_options);
+            let future = web3::api::Eth::new(&options.transport).send_transaction(options.transaction);
+            let future = timer.timeout(future.from_err(), options.request_timeout);
+
+            SendTransactionWithReceipt {
+                transport: options.transport,
+                state: State::AwaitSendTransaction(future),
+                block_number_stream,
+                request_timeout: options.request_timeout,
+                timer,
+            }
+        }
+    }
+
+    impl<T: Transport> Future for SendTransactionWithReceipt<T> {
+        type Item = TransactionReceipt;
+        type Error = error::Error;
+
+        fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+            loop {
+                let next_state = match self.state {
+                    State::AwaitSendTransaction(ref mut future) => {
+                        let hash = try_ready!(
+                            future
+                                .poll()
+                                .chain_err(|| "SendTransactionWithReceipt: sending transaction failed")
+                        );
+                        info!("SendTransactionWithReceipt: sent transaction {}", hash);
+                        State::AwaitBlockNumber(hash)
+                    },
+                    State::AwaitBlockNumber(transaction_hash) => {
+                        let last_block = match self.block_number_stream.poll() {
+                            Ok(Async::NotReady) => return Ok(Async::NotReady),
+                            Err(err) => return Err(err)
+                                .chain_err(|| "SendTransactionWithReceipt: fetching of last confirmed block failed"),
+                            Ok(Async::Ready(Some(last_block))) => last_block,
+                            Ok(Async::Ready(None)) => bail!("SendTransactionWithReceipt: fetching of last confirmed block failed"),
+                        };
+
+                        info!("SendTransactionWithReceipt: fetched confirmed block number {}", last_block);
+                        let future = web3::api::Eth::new(&self.transport).transaction_receipt(transaction_hash);
+                        State::AwaitTransactionReceipt {
+                            future: self.timer.timeout(future.from_err(), self.request_timeout),
+                            transaction_hash,
+                            last_block,
+                        }
+                    },
+                    State::AwaitTransactionReceipt { ref mut future, transaction_hash, last_block } => {
+                        let maybe_receipt = try_ready!(
+                            future
+                                .poll()
+                                .chain_err(|| "SendTransactionWithReceipt: getting transaction receipt failed")
+                        );
+
+                        match maybe_receipt {
+                            // transaction hasn't been mined yet
+                            None => State::AwaitBlockNumber(transaction_hash),
+                            Some(receipt) => {
+                                info!("SendTransactionWithReceipt: got transaction receipt: {}", transaction_hash);
+                                match receipt.block_number {
+                                    // receipt comes from pending block
+                                    None => State::AwaitBlockNumber(transaction_hash),
+                                    Some(receipt_block_number) => {
+                                        if last_block < receipt_block_number.as_u64() {
+                                            // transaction does not have enough confirmations
+                                            State::AwaitBlockNumber(transaction_hash)
+                                        } else {
+                                            return Ok(Async::Ready(receipt))
+                                        }
+                                    }
+                                }
+                            },
+                        }
+                    }
+                };
+
+                self.state = next_state;
+            }
+        }
+    }
+}
+
+enum State<T: Transport> {
+    AwaitBlockNumber {
+        future: Timeout<FromErr<CallFuture<U256, T::Out>, error::Error>>,
+        transaction: Option<TransactionRequest>,
+    },
+    AwaitReceipt(inner::SendTransactionWithReceipt<T>)
+}
+
+
+pub struct SendTransactionWithReceiptOptions<T> {
+    pub transport: T,
+    pub request_timeout: Duration,
+    pub poll_interval: Duration,
+    pub confirmations: u32,
+    pub transaction: TransactionRequest,
+}
+
+pub struct SendTransactionWithReceipt<T: Transport> {
+    request_timeout: Duration,
+    poll_interval: Duration,
+    transport: T,
+    state: State<T>,
+    confirmations: u32,
+}
+
+impl<T: Transport> SendTransactionWithReceipt<T> {
+    pub fn new(options: SendTransactionWithReceiptOptions<T>) -> Self {
+        let timer = Timer::default();
+
+        let future = web3::api::Eth::new(&options.transport).block_number();
+
+        let state = State::AwaitBlockNumber {
+            future: timer.timeout(future.from_err(), options.request_timeout),
+            transaction: Some(options.transaction),
+        };
+
+        SendTransactionWithReceipt {
+            request_timeout: options.request_timeout,
+            poll_interval: options.poll_interval,
+            transport: options.transport,
+            state,
+            confirmations: options.confirmations,
+        }
+    }
+}
+
+impl<T: Transport> Future for SendTransactionWithReceipt<T> {
+    type Item = TransactionReceipt;
+    type Error = error::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        loop {
+            let next_state = match self.state {
+                State::AwaitBlockNumber { ref mut future, ref mut transaction } => {
+                    let block_number = try_ready!(
+                        future
+                            .poll()
+                            .chain_err(|| "SendTransactionWithReceipt: fetching last block number failed")
+                    );
+                    info!("SendTransactionWithReceipt: got last block number {}", block_number);
+                    let transaction = transaction.take().expect("transaction should always be set");
+
+                    let inner_options = inner::SendTransactionWithReceiptOptions {
+                        transport: self.transport.clone(),
+                        request_timeout: self.request_timeout,
+                        poll_interval: self.poll_interval,
+                        confirmations: self.confirmations,
+                        transaction,
+                        after: block_number.as_u64(),
+                    };
+
+                    let future = inner::SendTransactionWithReceipt::new(inner_options);
+                    State::AwaitReceipt(future)
+                },
+                State::AwaitReceipt(ref mut future) => {
+                    return future.poll()
+                }
+            };
+
+            self.state = next_state;
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio_core::reactor::Core;
+    use super::*;
+
+    #[test]
+    fn test_send_tx_with_receipt() {
+        let transport = mock_transport!(
+            "eth_blockNumber" =>
+                req => json!([]),
+                res => json!("0x1010");
+            "eth_sendTransaction" =>
+                req => json!([{
+                    "data": "0x60",
+                    "from": "0x006b5dda44dc2606f07ad86c9190fb54fd905f6d",
+                    "gas": "0xf4240",
+                    "gasPrice": "0x0"
+                }]),
+                res => json!("0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34");
+            "eth_blockNumber" =>
+                req => json!([]),
+                res => json!("0x1011");
+            "eth_blockNumber" =>
+                req => json!([]),
+                res => json!("0x1012");
+            "eth_blockNumber" =>
+                req => json!([]),
+                res => json!("0x1013");
+            "eth_getTransactionReceipt" =>
+                req => json!(["0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34"]),
+                res => json!(null);
+            "eth_blockNumber" =>
+                req => json!([]),
+                res => json!("0x1014");
+            "eth_getTransactionReceipt" =>
+                req => json!(["0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34"]),
+                res => json!({
+                    "blockHash": null,
+                    "blockNumber": null,
+                    "contractAddress": "0xb1ac3a5584519119419a8e56422d912c782d8e5b",
+                    "cumulativeGasUsed": "0x1c1999",
+                    "gasUsed": "0xcdb5d",
+                    "logs": [],
+                    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "root": null,
+                    "status": "0x1",
+                    "transactionHash": "0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34",
+                    "transactionIndex":"0x4"
+                });
+            "eth_blockNumber" =>
+                req => json!([]),
+                res => json!("0x1014");
+            "eth_blockNumber" =>
+                req => json!([]),
+                res => json!("0x1015");
+            "eth_getTransactionReceipt" =>
+                req => json!(["0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34"]),
+                res => json!({
+                    "blockHash": "0xe0bdcf35b14a292d2998308d9b3fdea93a8c3d9c0b6c824c633fb9b15f9c3919",
+                    "blockNumber": "0x1015",
+                    "contractAddress": "0xb1ac3a5584519119419a8e56422d912c782d8e5b",
+                    "cumulativeGasUsed": "0x1c1999",
+                    "gasUsed": "0xcdb5d",
+                    "logs": [],
+                    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "root": null,
+                    "status": "0x1",
+                    "transactionHash": "0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34",
+                    "transactionIndex":"0x4"
+                });
+            "eth_blockNumber" =>
+                req => json!([]),
+                res => json!("0x1017");
+            "eth_getTransactionReceipt" =>
+                req => json!(["0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34"]),
+                res => json!({
+                    "blockHash": "0xe0bdcf35b14a292d2998308d9b3fdea93a8c3d9c0b6c824c633fb9b15f9c3919",
+                    "blockNumber": "0x1015",
+                    "contractAddress": "0xb1ac3a5584519119419a8e56422d912c782d8e5b",
+                    "cumulativeGasUsed": "0x1c1999",
+                    "gasUsed": "0xcdb5d",
+                    "logs": [],
+                    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "root": null,
+                    "status": "0x1",
+                    "transactionHash": "0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34",
+                    "transactionIndex":"0x4"
+                });
+        );
+
+        let send_transaction_with_receipt = SendTransactionWithReceipt::new(SendTransactionWithReceiptOptions {
+            transport: transport.clone(),
+            request_timeout: Duration::from_secs(1),
+            poll_interval: Duration::from_secs(0),
+            confirmations: 2,
+            transaction: TransactionRequest {
+                from: "0x006b5dda44dc2606f07ad86c9190fb54fd905f6d".into(),
+                to: None,
+                gas: Some(0xf4240.into()),
+                gas_price: Some(0.into()),
+                value: None,
+                data: Some(vec![0x60].into()),
+                nonce: None,
+                condition: None,
+            }
+        });
+
+        let mut event_loop = Core::new().unwrap();
+        let receipt = event_loop.run(send_transaction_with_receipt).unwrap();
+        assert_eq!(
+            receipt,
+            TransactionReceipt {
+                transaction_hash: "0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34".into(),
+                transaction_index: 0x4.into(),
+                block_hash: Some("0xe0bdcf35b14a292d2998308d9b3fdea93a8c3d9c0b6c824c633fb9b15f9c3919".into()),
+                block_number: Some(0x1015.into()),
+                cumulative_gas_used: 0x1c1999.into(),
+                gas_used: 0xcdb5d.into(),
+                contract_address: Some("0xb1ac3a5584519119419a8e56422d912c782d8e5b".into()),
+                logs: vec![],
+                status: Some(1.into()),
+            }
+        );
+        assert_eq!(transport.actual_requests(), transport.expected_requests());
+    }
+}


### PR DESCRIPTION
issues:
- closes #191 
- closes #196

changes:

- new `Stream` -> `BlockNumberStream` which yields confirmed blocks
- new `Future` -> `SendTransactionWithReceipt` which replaces buggy `web3::send_transaction_with_confirmation`

before merge:
- requires https://github.com/tomusdrw/rust-web3/pull/164

what caused the issue?

`eth_getTransactionReceipt` returns receipt with fields `block_hash` and `block_number` set to `null` for transactions that are a part of pending block. update to `rust-web3` fixes `TransactionReceipt` structure to take it into account, whereas `SendTransactionWithReceipt` stream waits for receipt until transaction becomes a member of a block with sufficient number of confirmations