### PR TITLE
Use tabs instead of spaces in rust code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 [*]
-indent_style=space
+indent_style=tab
 indent_size=4
 tab_width=4
 end_of_line=lf

--- a/bridge/build.rs
+++ b/bridge/build.rs
@@ -17,26 +17,26 @@
 use std::process::Command;
 
 fn main() {
-    // rerun build script if bridge contract has changed.
-    // without this cargo doesn't since the bridge contract
-    // is outside the crate directories
-    println!("cargo:rerun-if-changed=../arbitrary/contracts/bridge.sol");
+	// rerun build script if bridge contract has changed.
+	// without this cargo doesn't since the bridge contract
+	// is outside the crate directories
+	println!("cargo:rerun-if-changed=../arbitrary/contracts/bridge.sol");
 
-    // make last git commit hash (`git rev-parse HEAD`)
-    // available via `env!("GIT_HASH")` in sources
-    let output = Command::new("git")
-        .args(&["rev-parse", "HEAD"])
-        .output()
-        .expect("`git rev-parse HEAD` failed to run. run it yourself to verify. file an issue if this persists");
-    let git_hash = String::from_utf8(output.stdout).unwrap();
-    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+	// make last git commit hash (`git rev-parse HEAD`)
+	// available via `env!("GIT_HASH")` in sources
+	let output = Command::new("git")
+		.args(&["rev-parse", "HEAD"])
+		.output()
+		.expect("`git rev-parse HEAD` failed to run. run it yourself to verify. file an issue if this persists");
+	let git_hash = String::from_utf8(output.stdout).unwrap();
+	println!("cargo:rustc-env=GIT_HASH={}", git_hash);
 
-    // make solc version used to compile contracts (`solc --version`)
-    // available via `env!("SOLC_VERSION")` in sources
-    let output = Command::new("solc").args(&["--version"]).output().expect(
-        "`solc --version` failed to run. run it yourself to verify. file an issue if this persists",
-    );
-    let output_string = String::from_utf8(output.stdout).unwrap();
-    let solc_version = output_string.lines().last().unwrap();
-    println!("cargo:rustc-env=SOLC_VERSION={}", solc_version);
+	// make solc version used to compile contracts (`solc --version`)
+	// available via `env!("SOLC_VERSION")` in sources
+	let output = Command::new("solc").args(&["--version"]).output().expect(
+		"`solc --version` failed to run. run it yourself to verify. file an issue if this persists",
+	);
+	let output_string = String::from_utf8(output.stdout).unwrap();
+	let solc_version = output_string.lines().last().unwrap();
+	println!("cargo:rustc-env=SOLC_VERSION={}", solc_version);
 }

--- a/bridge/src/accept_message_from_main.rs
+++ b/bridge/src/accept_message_from_main.rs
@@ -26,381 +26,381 @@ use web3::Transport;
 
 #[derive(Clone)]
 pub struct LogToAcceptMessageFromMain<T> {
-    pub main: MainContract<T>,
-    pub side: SideContract<T>,
+	pub main: MainContract<T>,
+	pub side: SideContract<T>,
 }
 
 impl<T: Transport> LogToFuture for LogToAcceptMessageFromMain<T> {
-    type Future = AcceptMessageFromMain<T>;
+	type Future = AcceptMessageFromMain<T>;
 
-    fn log_to_future(&self, log: &Log) -> Self::Future {
-        AcceptMessageFromMain::new(log, self.side.clone(), self.main.clone())
-    }
+	fn log_to_future(&self, log: &Log) -> Self::Future {
+		AcceptMessageFromMain::new(log, self.side.clone(), self.main.clone())
+	}
 }
 
 enum State<T: Transport> {
-    AwaitMessage(AsyncCall<T, contracts::main::functions::relayed_messages::Decoder>),
-    AwaitAlreadyAccepted {
-        message: Vec<u8>,
-        future: AsyncCall<
-            T,
-            contracts::side::functions::has_authority_accepted_message_from_main::Decoder,
-        >,
-    },
-    AwaitTxSent(AsyncTransaction<T>),
+	AwaitMessage(AsyncCall<T, contracts::main::functions::relayed_messages::Decoder>),
+	AwaitAlreadyAccepted {
+		message: Vec<u8>,
+		future: AsyncCall<
+			T,
+			contracts::side::functions::has_authority_accepted_message_from_main::Decoder,
+		>,
+	},
+	AwaitTxSent(AsyncTransaction<T>),
 }
 
 pub struct AcceptMessageFromMain<T: Transport> {
-    state: State<T>,
-    main_tx_hash: H256,
-    sender: Address,
-    recipient: Address,
-    side: SideContract<T>,
+	state: State<T>,
+	main_tx_hash: H256,
+	sender: Address,
+	recipient: Address,
+	side: SideContract<T>,
 }
 
 impl<T: Transport> AcceptMessageFromMain<T> {
-    pub fn new(raw_log: &Log, side: SideContract<T>, main: MainContract<T>) -> Self {
-        let main_tx_hash = raw_log
-            .transaction_hash
-            .expect("`log` must be mined and contain `transaction_hash`. q.e.d.");
+	pub fn new(raw_log: &Log, side: SideContract<T>, main: MainContract<T>) -> Self {
+		let main_tx_hash = raw_log
+			.transaction_hash
+			.expect("`log` must be mined and contain `transaction_hash`. q.e.d.");
 
-        let log = helpers::parse_log(contracts::main::events::relay_message::parse_log, raw_log)
-            .expect("`log` must be for a relay message. q.e.d.");
+		let log = helpers::parse_log(contracts::main::events::relay_message::parse_log, raw_log)
+			.expect("`log` must be for a relay message. q.e.d.");
 
-        let sender = log.sender;
-        let recipient = log.recipient;
+		let sender = log.sender;
+		let recipient = log.recipient;
 
-        info!(
-            "{:?} - step 1/4 - fetch message using message_id",
-            main_tx_hash
-        );
-        let future = main.relayed_message_by_id(log.message_id);
-        let state = State::AwaitMessage(future);
+		info!(
+			"{:?} - step 1/4 - fetch message using message_id",
+			main_tx_hash
+		);
+		let future = main.relayed_message_by_id(log.message_id);
+		let state = State::AwaitMessage(future);
 
-        AcceptMessageFromMain {
-            state,
-            main_tx_hash,
-            sender,
-            recipient,
-            side,
-        }
-    }
+		AcceptMessageFromMain {
+			state,
+			main_tx_hash,
+			sender,
+			recipient,
+			side,
+		}
+	}
 }
 
 impl<T: Transport> Future for AcceptMessageFromMain<T> {
-    type Item = Option<H256>;
-    type Error = error::Error;
+	type Item = Option<H256>;
+	type Error = error::Error;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        loop {
-            let next_state = match self.state {
-                State::AwaitMessage(ref mut future) => {
-                    let message = try_ready!(future
-                        .poll()
-                        .chain_err(|| "AcceptMessageFromMain: failed to fetch the message"));
+	fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+		loop {
+			let next_state = match self.state {
+				State::AwaitMessage(ref mut future) => {
+					let message = try_ready!(future
+						.poll()
+						.chain_err(|| "AcceptMessageFromMain: failed to fetch the message"));
 
-                    info!(
-                        "{:?} - 2/4 - checking if the message is already signed",
-                        self.main_tx_hash
-                    );
-                    State::AwaitAlreadyAccepted {
-                        message: message.clone(),
-                        future: self.side.is_message_accepted_from_main(
-                            self.main_tx_hash,
-                            message,
-                            self.sender,
-                            self.recipient,
-                        ),
-                    }
-                }
-                State::AwaitAlreadyAccepted {
-                    ref message,
-                    ref mut future,
-                } => {
-                    let has_already_accepted = try_ready!(future.poll().chain_err(|| {
-                        "AcceptMessageFromMain: failed to check if already accepted"
-                    }));
-                    if has_already_accepted {
-                        info!("{:?} - DONE - already accepted", self.main_tx_hash);
-                        return Ok(Async::Ready(None));
-                    }
+					info!(
+						"{:?} - 2/4 - checking if the message is already signed",
+						self.main_tx_hash
+					);
+					State::AwaitAlreadyAccepted {
+						message: message.clone(),
+						future: self.side.is_message_accepted_from_main(
+							self.main_tx_hash,
+							message,
+							self.sender,
+							self.recipient,
+						),
+					}
+				}
+				State::AwaitAlreadyAccepted {
+					ref message,
+					ref mut future,
+				} => {
+					let has_already_accepted = try_ready!(future.poll().chain_err(|| {
+						"AcceptMessageFromMain: failed to check if already accepted"
+					}));
+					if has_already_accepted {
+						info!("{:?} - DONE - already accepted", self.main_tx_hash);
+						return Ok(Async::Ready(None));
+					}
 
-                    info!("{:?} - 3/4 - accepting the message", self.main_tx_hash);
-                    State::AwaitTxSent(self.side.accept_message_from_main(
-                        self.main_tx_hash,
-                        message.clone(),
-                        self.sender,
-                        self.recipient,
-                    ))
-                }
-                State::AwaitTxSent(ref mut future) => {
-                    let main_tx_hash = self.main_tx_hash;
-                    let side_tx_hash = try_ready!(future.poll().chain_err(|| format!(
-                        "AcceptMessageFromMain: checking whether {} was relayed failed",
-                        main_tx_hash
-                    )));
-                    info!("{:?} - DONE - accepted", self.main_tx_hash);
-                    return Ok(Async::Ready(Some(side_tx_hash)));
-                }
-            };
-            self.state = next_state;
-        }
-    }
+					info!("{:?} - 3/4 - accepting the message", self.main_tx_hash);
+					State::AwaitTxSent(self.side.accept_message_from_main(
+						self.main_tx_hash,
+						message.clone(),
+						self.sender,
+						self.recipient,
+					))
+				}
+				State::AwaitTxSent(ref mut future) => {
+					let main_tx_hash = self.main_tx_hash;
+					let side_tx_hash = try_ready!(future.poll().chain_err(|| format!(
+						"AcceptMessageFromMain: checking whether {} was relayed failed",
+						main_tx_hash
+					)));
+					info!("{:?} - DONE - accepted", self.main_tx_hash);
+					return Ok(Async::Ready(Some(side_tx_hash)));
+				}
+			};
+			self.state = next_state;
+		}
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use contracts;
-    use ethabi;
-    use rustc_hex::ToHex;
-    use tokio_core::reactor::Core;
-    use web3::types::{Bytes, Log};
+	use super::*;
+	use contracts;
+	use ethabi;
+	use rustc_hex::ToHex;
+	use tokio_core::reactor::Core;
+	use web3::types::{Bytes, Log};
 
-    #[test]
-    fn test_accept_message_from_main() {
-        let topic = contracts::main::events::relay_message::filter().topic0;
+	#[test]
+	fn test_accept_message_from_main() {
+		let topic = contracts::main::events::relay_message::filter().topic0;
 
-        let log = contracts::main::logs::RelayMessage {
-            message_id: "1db8f385535c0d178b8f40016048f3a3cffee8f94e68978ea4b277f57b638f0b"
-                .parse()
-                .unwrap(),
-            sender: "aff3454fce5edbc8cca8697c15331677e6ebdddd".parse().unwrap(),
-            recipient: "aff3454fce5edbc8cca8697c15331677e6ebcccc".parse().unwrap(),
-        };
+		let log = contracts::main::logs::RelayMessage {
+			message_id: "1db8f385535c0d178b8f40016048f3a3cffee8f94e68978ea4b277f57b638f0b"
+				.parse()
+				.unwrap(),
+			sender: "aff3454fce5edbc8cca8697c15331677e6ebdddd".parse().unwrap(),
+			recipient: "aff3454fce5edbc8cca8697c15331677e6ebcccc".parse().unwrap(),
+		};
 
-        let log_data = ethabi::encode(&[
-            ethabi::Token::FixedBytes(log.message_id.as_bytes().to_vec()),
-            ethabi::Token::Address(log.sender),
-            ethabi::Token::Address(log.recipient),
-        ]);
+		let log_data = ethabi::encode(&[
+			ethabi::Token::FixedBytes(log.message_id.as_bytes().to_vec()),
+			ethabi::Token::Address(log.sender),
+			ethabi::Token::Address(log.recipient),
+		]);
 
-        let log_tx_hash = "884edad9ce6fa2440d8a54cc123490eb96d2768479d49ff9c7366125a9424364"
-            .parse()
-            .unwrap();
+		let log_tx_hash = "884edad9ce6fa2440d8a54cc123490eb96d2768479d49ff9c7366125a9424364"
+			.parse()
+			.unwrap();
 
-        let raw_log = Log {
-            address: "0000000000000000000000000000000000000001".parse().unwrap(),
-            topics: topic.into(),
-            data: Bytes(log_data),
-            transaction_hash: Some(log_tx_hash),
-            block_hash: None,
-            block_number: None,
-            transaction_index: None,
-            log_index: None,
-            transaction_log_index: None,
-            log_type: None,
-            removed: None,
-        };
+		let raw_log = Log {
+			address: "0000000000000000000000000000000000000001".parse().unwrap(),
+			topics: topic.into(),
+			data: Bytes(log_data),
+			transaction_hash: Some(log_tx_hash),
+			block_hash: None,
+			block_number: None,
+			transaction_index: None,
+			log_index: None,
+			transaction_log_index: None,
+			log_type: None,
+			removed: None,
+		};
 
-        let authority_address = "0000000000000000000000000000000000000001".parse().unwrap();
+		let authority_address = "0000000000000000000000000000000000000001".parse().unwrap();
 
-        let tx_hash = "1db8f385535c0d178b8f40016048f3a3cffee8f94e68978ea4b277f57b638f0b";
-        let side_contract_address = "0000000000000000000000000000000000000dd1".parse().unwrap();
-        let main_contract_address = "0000000000000000000000000000000000000dd2".parse().unwrap();
+		let tx_hash = "1db8f385535c0d178b8f40016048f3a3cffee8f94e68978ea4b277f57b638f0b";
+		let side_contract_address = "0000000000000000000000000000000000000dd1".parse().unwrap();
+		let main_contract_address = "0000000000000000000000000000000000000dd2".parse().unwrap();
 
-        let data: Vec<u8> = vec![0x12, 0x34];
+		let data: Vec<u8> = vec![0x12, 0x34];
 
-        let encoded_message = ethabi::encode(&[ethabi::Token::Bytes(data.clone())]);
+		let encoded_message = ethabi::encode(&[ethabi::Token::Bytes(data.clone())]);
 
-        let get_message_call_data =
-            contracts::main::functions::relayed_messages::encode_input(log.message_id);
+		let get_message_call_data =
+			contracts::main::functions::relayed_messages::encode_input(log.message_id);
 
-        let has_accepted_call_data =
-            contracts::side::functions::has_authority_accepted_message_from_main::encode_input(
-                log_tx_hash,
-                data.clone(),
-                log.sender,
-                log.recipient,
-                authority_address,
-            );
+		let has_accepted_call_data =
+			contracts::side::functions::has_authority_accepted_message_from_main::encode_input(
+				log_tx_hash,
+				data.clone(),
+				log.sender,
+				log.recipient,
+				authority_address,
+			);
 
-        let accept_message_call_data = contracts::side::functions::accept_message::encode_input(
-            log_tx_hash,
-            data,
-            log.sender,
-            log.recipient,
-        );
+		let accept_message_call_data = contracts::side::functions::accept_message::encode_input(
+			log_tx_hash,
+			data,
+			log.sender,
+			log.recipient,
+		);
 
-        let main_transport = mock_transport!(
-            "eth_call" =>
-                req => json!([{
-                    "data": format!("0x{}", get_message_call_data.to_hex::<String>()),
-                    "to": format!("0x{:x}", main_contract_address),
-                }, "latest"]),
-                res => json!(format!("0x{}", encoded_message.to_hex::<String>()));
-        );
+		let main_transport = mock_transport!(
+			"eth_call" =>
+				req => json!([{
+					"data": format!("0x{}", get_message_call_data.to_hex::<String>()),
+					"to": format!("0x{:x}", main_contract_address),
+				}, "latest"]),
+				res => json!(format!("0x{}", encoded_message.to_hex::<String>()));
+		);
 
-        let side_transport = mock_transport!(
-            "eth_call" =>
-                req => json!([{
-                    "data": format!("0x{}", has_accepted_call_data.to_hex::<String>()),
-                    "to": format!("0x{:x}", side_contract_address),
-                }, "latest"]),
-                res => json!(format!("0x{}", ethabi::encode(&[ethabi::Token::Bool(false)]).to_hex::<String>()));
-            "eth_sendTransaction" =>
-                req => json!([{
-                    "data": format!("0x{}", accept_message_call_data.to_hex::<String>()),
-                    "from": "0x0000000000000000000000000000000000000001",
-                    "gas": "0xfd",
-                    "gasPrice": "0xa0",
-                    "to": format!("0x{:x}", side_contract_address),
-                }]),
-                res => json!(format!("0x{}", tx_hash));
-        );
+		let side_transport = mock_transport!(
+			"eth_call" =>
+				req => json!([{
+					"data": format!("0x{}", has_accepted_call_data.to_hex::<String>()),
+					"to": format!("0x{:x}", side_contract_address),
+				}, "latest"]),
+				res => json!(format!("0x{}", ethabi::encode(&[ethabi::Token::Bool(false)]).to_hex::<String>()));
+			"eth_sendTransaction" =>
+				req => json!([{
+					"data": format!("0x{}", accept_message_call_data.to_hex::<String>()),
+					"from": "0x0000000000000000000000000000000000000001",
+					"gas": "0xfd",
+					"gasPrice": "0xa0",
+					"to": format!("0x{:x}", side_contract_address),
+				}]),
+				res => json!(format!("0x{}", tx_hash));
+		);
 
-        let main_contract = MainContract {
-            transport: main_transport.clone(),
-            contract_address: main_contract_address,
-            authority_address,
-            submit_collected_signatures_gas: 0.into(),
-            request_timeout: ::std::time::Duration::from_millis(0),
-            logs_poll_interval: ::std::time::Duration::from_millis(0),
-            required_log_confirmations: 0,
-        };
+		let main_contract = MainContract {
+			transport: main_transport.clone(),
+			contract_address: main_contract_address,
+			authority_address,
+			submit_collected_signatures_gas: 0.into(),
+			request_timeout: ::std::time::Duration::from_millis(0),
+			logs_poll_interval: ::std::time::Duration::from_millis(0),
+			required_log_confirmations: 0,
+		};
 
-        let side_contract = SideContract {
-            transport: side_transport.clone(),
-            contract_address: side_contract_address,
-            authority_address,
-            required_signatures: 1,
-            request_timeout: ::std::time::Duration::from_millis(0),
-            logs_poll_interval: ::std::time::Duration::from_millis(0),
-            required_log_confirmations: 0,
-            sign_main_to_side_gas: 0xfd.into(),
-            sign_main_to_side_gas_price: 0xa0.into(),
-            sign_side_to_main_gas: 0.into(),
-            sign_side_to_main_gas_price: 0.into(),
-        };
+		let side_contract = SideContract {
+			transport: side_transport.clone(),
+			contract_address: side_contract_address,
+			authority_address,
+			required_signatures: 1,
+			request_timeout: ::std::time::Duration::from_millis(0),
+			logs_poll_interval: ::std::time::Duration::from_millis(0),
+			required_log_confirmations: 0,
+			sign_main_to_side_gas: 0xfd.into(),
+			sign_main_to_side_gas_price: 0xa0.into(),
+			sign_side_to_main_gas: 0.into(),
+			sign_side_to_main_gas_price: 0.into(),
+		};
 
-        let future = AcceptMessageFromMain::new(&raw_log, side_contract, main_contract);
+		let future = AcceptMessageFromMain::new(&raw_log, side_contract, main_contract);
 
-        let mut event_loop = Core::new().unwrap();
-        let result = event_loop.run(future).unwrap();
-        assert_eq!(result, Some(tx_hash.parse().unwrap()));
+		let mut event_loop = Core::new().unwrap();
+		let result = event_loop.run(future).unwrap();
+		assert_eq!(result, Some(tx_hash.parse().unwrap()));
 
-        assert_eq!(
-            side_transport.actual_requests(),
-            side_transport.expected_requests()
-        );
-        assert_eq!(
-            main_transport.actual_requests(),
-            main_transport.expected_requests()
-        );
-    }
+		assert_eq!(
+			side_transport.actual_requests(),
+			side_transport.expected_requests()
+		);
+		assert_eq!(
+			main_transport.actual_requests(),
+			main_transport.expected_requests()
+		);
+	}
 
-    #[test]
-    fn test_accept_message_from_main_already_relayed() {
-        let topic = contracts::main::events::relay_message::filter().topic0;
+	#[test]
+	fn test_accept_message_from_main_already_relayed() {
+		let topic = contracts::main::events::relay_message::filter().topic0;
 
-        let log = contracts::main::logs::RelayMessage {
-            message_id: "1db8f385535c0d178b8f40016048f3a3cffee8f94e68978ea4b277f57b638f0b"
-                .parse()
-                .unwrap(),
-            sender: "aff3454fce5edbc8cca8697c15331677e6ebdddd".parse().unwrap(),
-            recipient: "aff3454fce5edbc8cca8697c15331677e6ebcccc".parse().unwrap(),
-        };
+		let log = contracts::main::logs::RelayMessage {
+			message_id: "1db8f385535c0d178b8f40016048f3a3cffee8f94e68978ea4b277f57b638f0b"
+				.parse()
+				.unwrap(),
+			sender: "aff3454fce5edbc8cca8697c15331677e6ebdddd".parse().unwrap(),
+			recipient: "aff3454fce5edbc8cca8697c15331677e6ebcccc".parse().unwrap(),
+		};
 
-        let log_data = ethabi::encode(&[
-            ethabi::Token::FixedBytes(log.message_id.as_bytes().to_vec()),
-            ethabi::Token::Address(log.sender),
-            ethabi::Token::Address(log.recipient),
-        ]);
+		let log_data = ethabi::encode(&[
+			ethabi::Token::FixedBytes(log.message_id.as_bytes().to_vec()),
+			ethabi::Token::Address(log.sender),
+			ethabi::Token::Address(log.recipient),
+		]);
 
-        let log_tx_hash = "884edad9ce6fa2440d8a54cc123490eb96d2768479d49ff9c7366125a9424364"
-            .parse()
-            .unwrap();
+		let log_tx_hash = "884edad9ce6fa2440d8a54cc123490eb96d2768479d49ff9c7366125a9424364"
+			.parse()
+			.unwrap();
 
-        let raw_log = Log {
-            address: "0000000000000000000000000000000000000001".parse().unwrap(),
-            topics: topic.into(),
-            data: Bytes(log_data),
-            transaction_hash: Some(log_tx_hash),
-            block_hash: None,
-            block_number: None,
-            transaction_index: None,
-            log_index: None,
-            transaction_log_index: None,
-            log_type: None,
-            removed: None,
-        };
+		let raw_log = Log {
+			address: "0000000000000000000000000000000000000001".parse().unwrap(),
+			topics: topic.into(),
+			data: Bytes(log_data),
+			transaction_hash: Some(log_tx_hash),
+			block_hash: None,
+			block_number: None,
+			transaction_index: None,
+			log_index: None,
+			transaction_log_index: None,
+			log_type: None,
+			removed: None,
+		};
 
-        let authority_address = "0000000000000000000000000000000000000001".parse().unwrap();
+		let authority_address = "0000000000000000000000000000000000000001".parse().unwrap();
 
-        let side_contract_address = "0000000000000000000000000000000000000dd1".parse().unwrap();
-        let main_contract_address = "0000000000000000000000000000000000000dd2".parse().unwrap();
+		let side_contract_address = "0000000000000000000000000000000000000dd1".parse().unwrap();
+		let main_contract_address = "0000000000000000000000000000000000000dd2".parse().unwrap();
 
-        let data: Vec<u8> = vec![0x12, 0x34];
+		let data: Vec<u8> = vec![0x12, 0x34];
 
-        let encoded_message = ethabi::encode(&[ethabi::Token::Bytes(data.clone())]);
+		let encoded_message = ethabi::encode(&[ethabi::Token::Bytes(data.clone())]);
 
-        let get_message_call_data =
-            contracts::main::functions::relayed_messages::encode_input(log.message_id);
+		let get_message_call_data =
+			contracts::main::functions::relayed_messages::encode_input(log.message_id);
 
-        let has_accepted_call_data =
-            contracts::side::functions::has_authority_accepted_message_from_main::encode_input(
-                log_tx_hash,
-                data.clone(),
-                log.sender,
-                log.recipient,
-                authority_address,
-            );
+		let has_accepted_call_data =
+			contracts::side::functions::has_authority_accepted_message_from_main::encode_input(
+				log_tx_hash,
+				data.clone(),
+				log.sender,
+				log.recipient,
+				authority_address,
+			);
 
-        let main_transport = mock_transport!(
-            "eth_call" =>
-                req => json!([{
-                    "data": format!("0x{}", get_message_call_data.to_hex::<String>()),
-                    "to": main_contract_address,
-                }, "latest"]),
-                res => json!(format!("0x{}", encoded_message.to_hex::<String>()));
-        );
+		let main_transport = mock_transport!(
+			"eth_call" =>
+				req => json!([{
+					"data": format!("0x{}", get_message_call_data.to_hex::<String>()),
+					"to": main_contract_address,
+				}, "latest"]),
+				res => json!(format!("0x{}", encoded_message.to_hex::<String>()));
+		);
 
-        let side_transport = mock_transport!(
-            "eth_call" =>
-                req => json!([{
-                    "data": format!("0x{}", has_accepted_call_data.to_hex::<String>()),
-                    "to": side_contract_address,
-                }, "latest"]),
-                res => json!(format!("0x{}", ethabi::encode(&[ethabi::Token::Bool(true)]).to_hex::<String>()));
-        );
+		let side_transport = mock_transport!(
+			"eth_call" =>
+				req => json!([{
+					"data": format!("0x{}", has_accepted_call_data.to_hex::<String>()),
+					"to": side_contract_address,
+				}, "latest"]),
+				res => json!(format!("0x{}", ethabi::encode(&[ethabi::Token::Bool(true)]).to_hex::<String>()));
+		);
 
-        let main_contract = MainContract {
-            transport: main_transport.clone(),
-            contract_address: main_contract_address,
-            authority_address,
-            submit_collected_signatures_gas: 0.into(),
-            request_timeout: ::std::time::Duration::from_millis(0),
-            logs_poll_interval: ::std::time::Duration::from_millis(0),
-            required_log_confirmations: 0,
-        };
+		let main_contract = MainContract {
+			transport: main_transport.clone(),
+			contract_address: main_contract_address,
+			authority_address,
+			submit_collected_signatures_gas: 0.into(),
+			request_timeout: ::std::time::Duration::from_millis(0),
+			logs_poll_interval: ::std::time::Duration::from_millis(0),
+			required_log_confirmations: 0,
+		};
 
-        let side_contract = SideContract {
-            transport: side_transport.clone(),
-            contract_address: side_contract_address,
-            authority_address,
-            required_signatures: 1,
-            request_timeout: ::std::time::Duration::from_millis(0),
-            logs_poll_interval: ::std::time::Duration::from_millis(0),
-            required_log_confirmations: 0,
-            sign_main_to_side_gas: 0xfd.into(),
-            sign_main_to_side_gas_price: 0xa0.into(),
-            sign_side_to_main_gas: 0.into(),
-            sign_side_to_main_gas_price: 0.into(),
-        };
+		let side_contract = SideContract {
+			transport: side_transport.clone(),
+			contract_address: side_contract_address,
+			authority_address,
+			required_signatures: 1,
+			request_timeout: ::std::time::Duration::from_millis(0),
+			logs_poll_interval: ::std::time::Duration::from_millis(0),
+			required_log_confirmations: 0,
+			sign_main_to_side_gas: 0xfd.into(),
+			sign_main_to_side_gas_price: 0xa0.into(),
+			sign_side_to_main_gas: 0.into(),
+			sign_side_to_main_gas_price: 0.into(),
+		};
 
-        let future = AcceptMessageFromMain::new(&raw_log, side_contract, main_contract);
+		let future = AcceptMessageFromMain::new(&raw_log, side_contract, main_contract);
 
-        let mut event_loop = Core::new().unwrap();
-        let result = event_loop.run(future).unwrap();
-        assert_eq!(result, None);
+		let mut event_loop = Core::new().unwrap();
+		let result = event_loop.run(future).unwrap();
+		assert_eq!(result, None);
 
-        assert_eq!(
-            side_transport.actual_requests(),
-            side_transport.expected_requests()
-        );
-        assert_eq!(
-            main_transport.actual_requests(),
-            main_transport.expected_requests()
-        );
-    }
+		assert_eq!(
+			side_transport.actual_requests(),
+			side_transport.expected_requests()
+		);
+		assert_eq!(
+			main_transport.actual_requests(),
+			main_transport.expected_requests()
+		);
+	}
 }

--- a/bridge/src/block_number_stream.rs
+++ b/bridge/src/block_number_stream.rs
@@ -27,132 +27,132 @@ use web3::Transport;
 
 /// Block Number Stream state.
 enum State<T: Transport> {
-    AwaitInterval,
-    AwaitBlockNumber(Timeout<FromErr<CallFuture<U64, T::Out>, error::Error>>),
+	AwaitInterval,
+	AwaitBlockNumber(Timeout<FromErr<CallFuture<U64, T::Out>, error::Error>>),
 }
 
 pub struct BlockNumberStreamOptions<T> {
-    pub request_timeout: Duration,
-    pub poll_interval: Duration,
-    pub confirmations: u32,
-    pub transport: T,
-    pub after: u64,
+	pub request_timeout: Duration,
+	pub poll_interval: Duration,
+	pub confirmations: u32,
+	pub transport: T,
+	pub after: u64,
 }
 
 /// `Stream` that repeatedly polls `eth_blockNumber` and yields new block numbers.
 pub struct BlockNumberStream<T: Transport> {
-    request_timeout: Duration,
-    confirmations: u32,
-    transport: T,
-    last_checked_block: u64,
-    timer: Timer,
-    poll_interval: Interval,
-    state: State<T>,
+	request_timeout: Duration,
+	confirmations: u32,
+	transport: T,
+	last_checked_block: u64,
+	timer: Timer,
+	poll_interval: Interval,
+	state: State<T>,
 }
 
 impl<T: Transport> BlockNumberStream<T> {
-    pub fn new(options: BlockNumberStreamOptions<T>) -> Self {
-        let timer = Timer::default();
+	pub fn new(options: BlockNumberStreamOptions<T>) -> Self {
+		let timer = Timer::default();
 
-        BlockNumberStream {
-            request_timeout: options.request_timeout,
-            confirmations: options.confirmations,
-            poll_interval: timer.interval(options.poll_interval),
-            transport: options.transport,
-            last_checked_block: options.after,
-            timer,
-            state: State::AwaitInterval,
-        }
-    }
+		BlockNumberStream {
+			request_timeout: options.request_timeout,
+			confirmations: options.confirmations,
+			poll_interval: timer.interval(options.poll_interval),
+			transport: options.transport,
+			last_checked_block: options.after,
+			timer,
+			state: State::AwaitInterval,
+		}
+	}
 }
 
 impl<T: Transport> Stream for BlockNumberStream<T> {
-    type Item = u64;
-    type Error = error::Error;
+	type Item = u64;
+	type Error = error::Error;
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        loop {
-            let (next_state, value_to_yield) = match self.state {
-                State::AwaitInterval => {
-                    // wait until `interval` has passed
-                    let _ = try_stream!(self
-                        .poll_interval
-                        .poll()
-                        .chain_err(|| format!("BlockNumberStream polling interval failed",)));
-                    info!("BlockNumberStream polling last block number");
-                    let future = web3::api::Eth::new(&self.transport).block_number();
-                    let next_state = State::AwaitBlockNumber(
-                        self.timer.timeout(future.from_err(), self.request_timeout),
-                    );
-                    (next_state, None)
-                }
-                State::AwaitBlockNumber(ref mut future) => {
-                    let last_block = try_ready!(future
-                        .poll()
-                        .chain_err(|| "BlockNumberStream: fetching of last block number failed"))
-                    .as_u64();
-                    info!(
-                        "BlockNumberStream: fetched last block number {}",
-                        last_block
-                    );
-                    // subtraction that saturates at zero
-                    let last_confirmed_block = last_block.saturating_sub(self.confirmations as u64);
+	fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+		loop {
+			let (next_state, value_to_yield) = match self.state {
+				State::AwaitInterval => {
+					// wait until `interval` has passed
+					let _ = try_stream!(self
+						.poll_interval
+						.poll()
+						.chain_err(|| format!("BlockNumberStream polling interval failed",)));
+					info!("BlockNumberStream polling last block number");
+					let future = web3::api::Eth::new(&self.transport).block_number();
+					let next_state = State::AwaitBlockNumber(
+						self.timer.timeout(future.from_err(), self.request_timeout),
+					);
+					(next_state, None)
+				}
+				State::AwaitBlockNumber(ref mut future) => {
+					let last_block = try_ready!(future
+						.poll()
+						.chain_err(|| "BlockNumberStream: fetching of last block number failed"))
+					.as_u64();
+					info!(
+						"BlockNumberStream: fetched last block number {}",
+						last_block
+					);
+					// subtraction that saturates at zero
+					let last_confirmed_block = last_block.saturating_sub(self.confirmations as u64);
 
-                    if self.last_checked_block < last_confirmed_block {
-                        self.last_checked_block = last_confirmed_block;
-                        (State::AwaitInterval, Some(last_confirmed_block))
-                    } else {
-                        info!("BlockNumberStream: no blocks confirmed since we last checked. waiting some more");
-                        (State::AwaitInterval, None)
-                    }
-                }
-            };
+					if self.last_checked_block < last_confirmed_block {
+						self.last_checked_block = last_confirmed_block;
+						(State::AwaitInterval, Some(last_confirmed_block))
+					} else {
+						info!("BlockNumberStream: no blocks confirmed since we last checked. waiting some more");
+						(State::AwaitInterval, None)
+					}
+				}
+			};
 
-            self.state = next_state;
+			self.state = next_state;
 
-            if value_to_yield.is_some() {
-                return Ok(Async::Ready(value_to_yield));
-            }
-        }
-    }
+			if value_to_yield.is_some() {
+				return Ok(Async::Ready(value_to_yield));
+			}
+		}
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use tokio_core::reactor::Core;
+	use super::*;
+	use tokio_core::reactor::Core;
 
-    #[test]
-    fn test_block_number_stream() {
-        let transport = mock_transport!(
-            "eth_blockNumber" =>
-                req => json!([]),
-                res => json!("0x1011");
-            "eth_blockNumber" =>
-                req => json!([]),
-                res => json!("0x1011");
-            "eth_blockNumber" =>
-                req => json!([]),
-                res => json!("0x1012");
-            "eth_blockNumber" =>
-                req => json!([]),
-                res => json!("0x1015");
-        );
+	#[test]
+	fn test_block_number_stream() {
+		let transport = mock_transport!(
+			"eth_blockNumber" =>
+				req => json!([]),
+				res => json!("0x1011");
+			"eth_blockNumber" =>
+				req => json!([]),
+				res => json!("0x1011");
+			"eth_blockNumber" =>
+				req => json!([]),
+				res => json!("0x1012");
+			"eth_blockNumber" =>
+				req => json!([]),
+				res => json!("0x1015");
+		);
 
-        let block_number_stream = BlockNumberStream::new(BlockNumberStreamOptions {
-            request_timeout: Duration::from_secs(1),
-            poll_interval: Duration::from_secs(0),
-            confirmations: 12,
-            transport: transport.clone(),
-            after: 3,
-        });
+		let block_number_stream = BlockNumberStream::new(BlockNumberStreamOptions {
+			request_timeout: Duration::from_secs(1),
+			poll_interval: Duration::from_secs(0),
+			confirmations: 12,
+			transport: transport.clone(),
+			after: 3,
+		});
 
-        let mut event_loop = Core::new().unwrap();
-        let block_numbers = event_loop
-            .run(block_number_stream.take(3).collect())
-            .unwrap();
+		let mut event_loop = Core::new().unwrap();
+		let block_numbers = event_loop
+			.run(block_number_stream.take(3).collect())
+			.unwrap();
 
-        assert_eq!(block_numbers, vec![0x1011 - 12, 0x1012 - 12, 0x1015 - 12]);
-        assert_eq!(transport.actual_requests(), transport.expected_requests());
-    }
+		assert_eq!(block_numbers, vec![0x1011 - 12, 0x1012 - 12, 0x1015 - 12]);
+		assert_eq!(transport.actual_requests(), transport.expected_requests());
+	}
 }

--- a/bridge/src/bridge.rs
+++ b/bridge/src/bridge.rs
@@ -35,107 +35,107 @@ use side_to_main_signatures;
 /// updates the database with results returned from relay streams.
 /// yields new state that should be persisted
 pub struct Bridge<T: Transport> {
-    accept_message_from_main:
-        RelayStream<LogStream<T>, accept_message_from_main::LogToAcceptMessageFromMain<T>>,
-    side_to_main_sign: RelayStream<LogStream<T>, side_to_main_sign::LogToSideToMainSign<T>>,
-    side_to_main_signatures:
-        RelayStream<LogStream<T>, side_to_main_signatures::LogToSideToMainSignatures<T>>,
-    state: State,
+	accept_message_from_main:
+		RelayStream<LogStream<T>, accept_message_from_main::LogToAcceptMessageFromMain<T>>,
+	side_to_main_sign: RelayStream<LogStream<T>, side_to_main_sign::LogToSideToMainSign<T>>,
+	side_to_main_signatures:
+		RelayStream<LogStream<T>, side_to_main_signatures::LogToSideToMainSignatures<T>>,
+	state: State,
 }
 
 impl<T: Transport> Bridge<T> {
-    pub fn new(
-        initial_state: State,
-        main_contract: MainContract<T>,
-        side_contract: SideContract<T>,
-    ) -> Self {
-        let accept_message_from_main = RelayStream::new(
-            main_contract.main_to_side_log_stream(initial_state.last_main_to_side_sign_at_block),
-            accept_message_from_main::LogToAcceptMessageFromMain {
-                main: main_contract.clone(),
-                side: side_contract.clone(),
-            },
-        );
+	pub fn new(
+		initial_state: State,
+		main_contract: MainContract<T>,
+		side_contract: SideContract<T>,
+	) -> Self {
+		let accept_message_from_main = RelayStream::new(
+			main_contract.main_to_side_log_stream(initial_state.last_main_to_side_sign_at_block),
+			accept_message_from_main::LogToAcceptMessageFromMain {
+				main: main_contract.clone(),
+				side: side_contract.clone(),
+			},
+		);
 
-        let side_to_main_sign = RelayStream::new(
-            side_contract
-                .side_to_main_sign_log_stream(initial_state.last_side_to_main_sign_at_block),
-            side_to_main_sign::LogToSideToMainSign {
-                side: side_contract.clone(),
-            },
-        );
+		let side_to_main_sign = RelayStream::new(
+			side_contract
+				.side_to_main_sign_log_stream(initial_state.last_side_to_main_sign_at_block),
+			side_to_main_sign::LogToSideToMainSign {
+				side: side_contract.clone(),
+			},
+		);
 
-        let side_to_main_signatures = RelayStream::new(
-            side_contract.side_to_main_signatures_log_stream(
-                initial_state.last_side_to_main_signatures_at_block,
-                main_contract.authority_address,
-            ),
-            side_to_main_signatures::LogToSideToMainSignatures {
-                main: main_contract.clone(),
-                side: side_contract.clone(),
-            },
-        );
+		let side_to_main_signatures = RelayStream::new(
+			side_contract.side_to_main_signatures_log_stream(
+				initial_state.last_side_to_main_signatures_at_block,
+				main_contract.authority_address,
+			),
+			side_to_main_signatures::LogToSideToMainSignatures {
+				main: main_contract.clone(),
+				side: side_contract.clone(),
+			},
+		);
 
-        Self {
-            accept_message_from_main,
-            side_to_main_sign,
-            side_to_main_signatures,
-            state: initial_state,
-        }
-    }
+		Self {
+			accept_message_from_main,
+			side_to_main_sign,
+			side_to_main_signatures,
+			state: initial_state,
+		}
+	}
 }
 
 impl<T: Transport> Stream for Bridge<T> {
-    type Item = State;
-    type Error = error::Error;
+	type Item = State;
+	type Error = error::Error;
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        loop {
-            let maybe_main_to_side_sign = try_maybe_stream!(self
-                .accept_message_from_main
-                .poll()
-                .chain_err(|| "Bridge: polling main to side sign failed"));
-            let maybe_side_to_main_sign = try_maybe_stream!(self
-                .side_to_main_sign
-                .poll()
-                .chain_err(|| "Bridge: polling side to main sign failed"));
-            let maybe_side_to_main_signatures = try_maybe_stream!(self
-                .side_to_main_signatures
-                .poll()
-                .chain_err(|| "Bridge: polling side to main signatures failed"));
+	fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+		loop {
+			let maybe_main_to_side_sign = try_maybe_stream!(self
+				.accept_message_from_main
+				.poll()
+				.chain_err(|| "Bridge: polling main to side sign failed"));
+			let maybe_side_to_main_sign = try_maybe_stream!(self
+				.side_to_main_sign
+				.poll()
+				.chain_err(|| "Bridge: polling side to main sign failed"));
+			let maybe_side_to_main_signatures = try_maybe_stream!(self
+				.side_to_main_signatures
+				.poll()
+				.chain_err(|| "Bridge: polling side to main signatures failed"));
 
-            let mut has_state_changed = false;
+			let mut has_state_changed = false;
 
-            if let Some(main_to_side_sign) = maybe_main_to_side_sign {
-                info!(
-                    "last block checked for main to side sign is now {}",
-                    main_to_side_sign
-                );
-                self.state.last_main_to_side_sign_at_block = main_to_side_sign;
-                has_state_changed = true;
-            }
-            if let Some(side_to_main_sign) = maybe_side_to_main_sign {
-                info!(
-                    "last block checked for side to main sign is now {}",
-                    side_to_main_sign
-                );
-                self.state.last_side_to_main_sign_at_block = side_to_main_sign;
-                has_state_changed = true;
-            }
-            if let Some(side_to_main_signatures) = maybe_side_to_main_signatures {
-                info!(
-                    "last block checked for side to main signatures is now {}",
-                    side_to_main_signatures
-                );
-                self.state.last_side_to_main_signatures_at_block = side_to_main_signatures;
-                has_state_changed = true;
-            }
+			if let Some(main_to_side_sign) = maybe_main_to_side_sign {
+				info!(
+					"last block checked for main to side sign is now {}",
+					main_to_side_sign
+				);
+				self.state.last_main_to_side_sign_at_block = main_to_side_sign;
+				has_state_changed = true;
+			}
+			if let Some(side_to_main_sign) = maybe_side_to_main_sign {
+				info!(
+					"last block checked for side to main sign is now {}",
+					side_to_main_sign
+				);
+				self.state.last_side_to_main_sign_at_block = side_to_main_sign;
+				has_state_changed = true;
+			}
+			if let Some(side_to_main_signatures) = maybe_side_to_main_signatures {
+				info!(
+					"last block checked for side to main signatures is now {}",
+					side_to_main_signatures
+				);
+				self.state.last_side_to_main_signatures_at_block = side_to_main_signatures;
+				has_state_changed = true;
+			}
 
-            if has_state_changed {
-                return Ok(Async::Ready(Some(self.state.clone())));
-            } else {
-                return Ok(Async::NotReady);
-            }
-        }
-    }
+			if has_state_changed {
+				return Ok(Async::Ready(Some(self.state.clone())));
+			} else {
+				return Ok(Async::NotReady);
+			}
+		}
+	}
 }

--- a/bridge/src/config.rs
+++ b/bridge/src/config.rs
@@ -34,226 +34,226 @@ const DEFAULT_CONFIRMATIONS: u32 = 12;
 /// Application config.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Config {
-    pub address: Address,
-    pub main: NodeConfig,
-    pub side: NodeConfig,
-    pub authorities: Authorities,
-    pub txs: Transactions,
-    pub estimated_gas_cost_of_withdraw: U256,
-    pub max_total_main_contract_balance: U256,
-    pub max_single_deposit_value: U256,
+	pub address: Address,
+	pub main: NodeConfig,
+	pub side: NodeConfig,
+	pub authorities: Authorities,
+	pub txs: Transactions,
+	pub estimated_gas_cost_of_withdraw: U256,
+	pub max_total_main_contract_balance: U256,
+	pub max_single_deposit_value: U256,
 }
 
 impl Config {
-    pub fn load<P: AsRef<Path>>(path: P) -> Result<Config, Error> {
-        let mut file = fs::File::open(path).chain_err(|| "Cannot open config")?;
-        let mut buffer = String::new();
-        file.read_to_string(&mut buffer).expect("TODO");
-        Self::load_from_str(&buffer)
-    }
+	pub fn load<P: AsRef<Path>>(path: P) -> Result<Config, Error> {
+		let mut file = fs::File::open(path).chain_err(|| "Cannot open config")?;
+		let mut buffer = String::new();
+		file.read_to_string(&mut buffer).expect("TODO");
+		Self::load_from_str(&buffer)
+	}
 
-    fn load_from_str(s: &str) -> Result<Config, Error> {
-        let config: load::Config = toml::from_str(s).chain_err(|| "Cannot parse config")?;
-        Config::from_load_struct(config)
-    }
+	fn load_from_str(s: &str) -> Result<Config, Error> {
+		let config: load::Config = toml::from_str(s).chain_err(|| "Cannot parse config")?;
+		Config::from_load_struct(config)
+	}
 
-    fn from_load_struct(config: load::Config) -> Result<Config, Error> {
-        let result = Config {
-            address: config.address,
-            main: NodeConfig::from_load_struct(config.main)?,
-            side: NodeConfig::from_load_struct(config.side)?,
-            authorities: Authorities {
-                accounts: config.authorities.accounts,
-                required_signatures: config.authorities.required_signatures,
-            },
-            txs: config
-                .transactions
-                .map(Transactions::from_load_struct)
-                .unwrap_or_default(),
-            estimated_gas_cost_of_withdraw: config.estimated_gas_cost_of_withdraw,
-            max_total_main_contract_balance: config.max_total_main_contract_balance,
-            max_single_deposit_value: config.max_single_deposit_value,
-        };
+	fn from_load_struct(config: load::Config) -> Result<Config, Error> {
+		let result = Config {
+			address: config.address,
+			main: NodeConfig::from_load_struct(config.main)?,
+			side: NodeConfig::from_load_struct(config.side)?,
+			authorities: Authorities {
+				accounts: config.authorities.accounts,
+				required_signatures: config.authorities.required_signatures,
+			},
+			txs: config
+				.transactions
+				.map(Transactions::from_load_struct)
+				.unwrap_or_default(),
+			estimated_gas_cost_of_withdraw: config.estimated_gas_cost_of_withdraw,
+			max_total_main_contract_balance: config.max_total_main_contract_balance,
+			max_single_deposit_value: config.max_single_deposit_value,
+		};
 
-        Ok(result)
-    }
+		Ok(result)
+	}
 }
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct NodeConfig {
-    pub contract: ContractConfig,
-    pub http: String,
-    pub request_timeout: Duration,
-    pub poll_interval: Duration,
-    pub required_confirmations: u32,
+	pub contract: ContractConfig,
+	pub http: String,
+	pub request_timeout: Duration,
+	pub poll_interval: Duration,
+	pub required_confirmations: u32,
 }
 
 impl NodeConfig {
-    fn from_load_struct(node: load::NodeConfig) -> Result<NodeConfig, Error> {
-        let result = Self {
-            contract: ContractConfig {
-                bin: {
-                    let mut read = String::new();
-                    let mut file = fs::File::open(&node.contract.bin).chain_err(|| {
-                        format!(
-                            "Cannot open compiled contract file at {}",
-                            node.contract.bin.to_string_lossy()
-                        )
-                    })?;
-                    file.read_to_string(&mut read)?;
-                    Bytes(read.from_hex()?)
-                },
-            },
-            http: node.http,
-            request_timeout: Duration::from_secs(node.request_timeout.unwrap_or(DEFAULT_TIMEOUT)),
-            poll_interval: Duration::from_secs(node.poll_interval.unwrap_or(DEFAULT_POLL_INTERVAL)),
-            required_confirmations: node.required_confirmations.unwrap_or(DEFAULT_CONFIRMATIONS),
-        };
+	fn from_load_struct(node: load::NodeConfig) -> Result<NodeConfig, Error> {
+		let result = Self {
+			contract: ContractConfig {
+				bin: {
+					let mut read = String::new();
+					let mut file = fs::File::open(&node.contract.bin).chain_err(|| {
+						format!(
+							"Cannot open compiled contract file at {}",
+							node.contract.bin.to_string_lossy()
+						)
+					})?;
+					file.read_to_string(&mut read)?;
+					Bytes(read.from_hex()?)
+				},
+			},
+			http: node.http,
+			request_timeout: Duration::from_secs(node.request_timeout.unwrap_or(DEFAULT_TIMEOUT)),
+			poll_interval: Duration::from_secs(node.poll_interval.unwrap_or(DEFAULT_POLL_INTERVAL)),
+			required_confirmations: node.required_confirmations.unwrap_or(DEFAULT_CONFIRMATIONS),
+		};
 
-        Ok(result)
-    }
+		Ok(result)
+	}
 }
 
 #[derive(Debug, PartialEq, Default, Clone)]
 pub struct Transactions {
-    pub main_deploy: TransactionConfig,
-    pub side_deploy: TransactionConfig,
-    pub deposit_relay: TransactionConfig,
-    pub withdraw_confirm: TransactionConfig,
-    pub withdraw_relay: TransactionConfig,
+	pub main_deploy: TransactionConfig,
+	pub side_deploy: TransactionConfig,
+	pub deposit_relay: TransactionConfig,
+	pub withdraw_confirm: TransactionConfig,
+	pub withdraw_relay: TransactionConfig,
 }
 
 impl Transactions {
-    fn from_load_struct(cfg: load::Transactions) -> Self {
-        Transactions {
-            main_deploy: cfg
-                .main_deploy
-                .map(TransactionConfig::from_load_struct)
-                .unwrap_or_default(),
-            side_deploy: cfg
-                .side_deploy
-                .map(TransactionConfig::from_load_struct)
-                .unwrap_or_default(),
-            deposit_relay: cfg
-                .deposit_relay
-                .map(TransactionConfig::from_load_struct)
-                .unwrap_or_default(),
-            withdraw_confirm: cfg
-                .withdraw_confirm
-                .map(TransactionConfig::from_load_struct)
-                .unwrap_or_default(),
-            withdraw_relay: cfg
-                .withdraw_relay
-                .map(TransactionConfig::from_load_struct)
-                .unwrap_or_default(),
-        }
-    }
+	fn from_load_struct(cfg: load::Transactions) -> Self {
+		Transactions {
+			main_deploy: cfg
+				.main_deploy
+				.map(TransactionConfig::from_load_struct)
+				.unwrap_or_default(),
+			side_deploy: cfg
+				.side_deploy
+				.map(TransactionConfig::from_load_struct)
+				.unwrap_or_default(),
+			deposit_relay: cfg
+				.deposit_relay
+				.map(TransactionConfig::from_load_struct)
+				.unwrap_or_default(),
+			withdraw_confirm: cfg
+				.withdraw_confirm
+				.map(TransactionConfig::from_load_struct)
+				.unwrap_or_default(),
+			withdraw_relay: cfg
+				.withdraw_relay
+				.map(TransactionConfig::from_load_struct)
+				.unwrap_or_default(),
+		}
+	}
 }
 
 #[derive(Debug, PartialEq, Default, Clone)]
 pub struct TransactionConfig {
-    pub gas: U256,
-    pub gas_price: U256,
+	pub gas: U256,
+	pub gas_price: U256,
 }
 
 impl TransactionConfig {
-    fn from_load_struct(cfg: load::TransactionConfig) -> Self {
-        TransactionConfig {
-            gas: cfg.gas,
-            gas_price: cfg.gas_price,
-        }
-    }
+	fn from_load_struct(cfg: load::TransactionConfig) -> Self {
+		TransactionConfig {
+			gas: cfg.gas,
+			gas_price: cfg.gas_price,
+		}
+	}
 }
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct ContractConfig {
-    pub bin: Bytes,
+	pub bin: Bytes,
 }
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Authorities {
-    pub accounts: Vec<Address>,
-    pub required_signatures: u32,
+	pub accounts: Vec<Address>,
+	pub required_signatures: u32,
 }
 
 /// Some config values may not be defined in `toml` file, but they should be specified at runtime.
 /// `load` module separates `Config` representation in file with optional from the one used
 /// in application.
 mod load {
-    use ethereum_types::U256;
-    use helpers::deserialize_u256;
-    use std::path::PathBuf;
-    use web3::types::Address;
+	use ethereum_types::U256;
+	use helpers::deserialize_u256;
+	use std::path::PathBuf;
+	use web3::types::Address;
 
-    #[derive(Deserialize)]
-    #[serde(deny_unknown_fields)]
-    pub struct Config {
-        pub address: Address,
-        pub main: NodeConfig,
-        pub side: NodeConfig,
-        pub authorities: Authorities,
-        pub transactions: Option<Transactions>,
-        #[serde(deserialize_with = "deserialize_u256")]
-        pub estimated_gas_cost_of_withdraw: U256,
-        #[serde(deserialize_with = "deserialize_u256")]
-        pub max_total_main_contract_balance: U256,
-        #[serde(deserialize_with = "deserialize_u256")]
-        pub max_single_deposit_value: U256,
-    }
+	#[derive(Deserialize)]
+	#[serde(deny_unknown_fields)]
+	pub struct Config {
+		pub address: Address,
+		pub main: NodeConfig,
+		pub side: NodeConfig,
+		pub authorities: Authorities,
+		pub transactions: Option<Transactions>,
+		#[serde(deserialize_with = "deserialize_u256")]
+		pub estimated_gas_cost_of_withdraw: U256,
+		#[serde(deserialize_with = "deserialize_u256")]
+		pub max_total_main_contract_balance: U256,
+		#[serde(deserialize_with = "deserialize_u256")]
+		pub max_single_deposit_value: U256,
+	}
 
-    #[derive(Deserialize)]
-    #[serde(deny_unknown_fields)]
-    pub struct NodeConfig {
-        pub contract: ContractConfig,
-        pub http: String,
-        pub request_timeout: Option<u64>,
-        pub poll_interval: Option<u64>,
-        pub required_confirmations: Option<u32>,
-    }
+	#[derive(Deserialize)]
+	#[serde(deny_unknown_fields)]
+	pub struct NodeConfig {
+		pub contract: ContractConfig,
+		pub http: String,
+		pub request_timeout: Option<u64>,
+		pub poll_interval: Option<u64>,
+		pub required_confirmations: Option<u32>,
+	}
 
-    #[derive(Deserialize)]
-    #[serde(deny_unknown_fields)]
-    pub struct Transactions {
-        pub main_deploy: Option<TransactionConfig>,
-        pub side_deploy: Option<TransactionConfig>,
-        pub deposit_relay: Option<TransactionConfig>,
-        pub withdraw_confirm: Option<TransactionConfig>,
-        pub withdraw_relay: Option<TransactionConfig>,
-    }
+	#[derive(Deserialize)]
+	#[serde(deny_unknown_fields)]
+	pub struct Transactions {
+		pub main_deploy: Option<TransactionConfig>,
+		pub side_deploy: Option<TransactionConfig>,
+		pub deposit_relay: Option<TransactionConfig>,
+		pub withdraw_confirm: Option<TransactionConfig>,
+		pub withdraw_relay: Option<TransactionConfig>,
+	}
 
-    #[derive(Deserialize)]
-    #[serde(deny_unknown_fields)]
-    pub struct TransactionConfig {
-        #[serde(deserialize_with = "deserialize_u256")]
-        pub gas: U256,
-        #[serde(deserialize_with = "deserialize_u256")]
-        pub gas_price: U256,
-    }
+	#[derive(Deserialize)]
+	#[serde(deny_unknown_fields)]
+	pub struct TransactionConfig {
+		#[serde(deserialize_with = "deserialize_u256")]
+		pub gas: U256,
+		#[serde(deserialize_with = "deserialize_u256")]
+		pub gas_price: U256,
+	}
 
-    #[derive(Deserialize)]
-    #[serde(deny_unknown_fields)]
-    pub struct ContractConfig {
-        pub bin: PathBuf,
-    }
+	#[derive(Deserialize)]
+	#[serde(deny_unknown_fields)]
+	pub struct ContractConfig {
+		pub bin: PathBuf,
+	}
 
-    #[derive(Deserialize)]
-    #[serde(deny_unknown_fields)]
-    pub struct Authorities {
-        pub accounts: Vec<Address>,
-        pub required_signatures: u32,
-    }
+	#[derive(Deserialize)]
+	#[serde(deny_unknown_fields)]
+	pub struct Authorities {
+		pub accounts: Vec<Address>,
+		pub required_signatures: u32,
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{Authorities, Config, ContractConfig, NodeConfig, TransactionConfig, Transactions};
-    use ethereum_types::U256;
-    use rustc_hex::FromHex;
-    use std::time::Duration;
+	use super::{Authorities, Config, ContractConfig, NodeConfig, TransactionConfig, Transactions};
+	use ethereum_types::U256;
+	use rustc_hex::FromHex;
+	use std::time::Duration;
 
-    #[test]
-    fn load_full_setup_from_str() {
-        let toml = r#"
+	#[test]
+	fn load_full_setup_from_str() {
+		let toml = r#"
 address = "0x1B68Cb0B50181FC4006Ce572cF346e596E51818b"
 estimated_gas_cost_of_withdraw = "100000"
 max_total_main_contract_balance = "10000000000000000000"
@@ -285,58 +285,58 @@ required_signatures = 2
 main_deploy = { gas = "20", gas_price = "0" }
 "#;
 
-        let mut expected = Config {
-            address: "1B68Cb0B50181FC4006Ce572cF346e596E51818b".parse().unwrap(),
-            txs: Transactions::default(),
-            main: NodeConfig {
-                http: "http://localhost:8545".into(),
-                contract: ContractConfig {
-                    bin: include_str!("../../compiled_contracts/Main.bin")
-                        .from_hex::<Vec<u8>>()
-                        .unwrap()
-                        .into(),
-                },
-                poll_interval: Duration::from_secs(2),
-                request_timeout: Duration::from_secs(5),
-                required_confirmations: 100,
-            },
-            side: NodeConfig {
-                contract: ContractConfig {
-                    bin: include_str!("../../compiled_contracts/Side.bin")
-                        .from_hex::<Vec<u8>>()
-                        .unwrap()
-                        .into(),
-                },
-                http: "http://localhost:8546".into(),
-                poll_interval: Duration::from_secs(1),
-                request_timeout: Duration::from_secs(5),
-                required_confirmations: 12,
-            },
-            authorities: Authorities {
-                accounts: vec![
-                    "0000000000000000000000000000000000000001".parse().unwrap(),
-                    "0000000000000000000000000000000000000002".parse().unwrap(),
-                    "0000000000000000000000000000000000000003".parse().unwrap(),
-                ],
-                required_signatures: 2,
-            },
-            estimated_gas_cost_of_withdraw: U256::from_dec_str("100000").unwrap(),
-            max_total_main_contract_balance: U256::from_dec_str("10000000000000000000").unwrap(),
-            max_single_deposit_value: U256::from_dec_str("1000000000000000000").unwrap(),
-        };
+		let mut expected = Config {
+			address: "1B68Cb0B50181FC4006Ce572cF346e596E51818b".parse().unwrap(),
+			txs: Transactions::default(),
+			main: NodeConfig {
+				http: "http://localhost:8545".into(),
+				contract: ContractConfig {
+					bin: include_str!("../../compiled_contracts/Main.bin")
+						.from_hex::<Vec<u8>>()
+						.unwrap()
+						.into(),
+				},
+				poll_interval: Duration::from_secs(2),
+				request_timeout: Duration::from_secs(5),
+				required_confirmations: 100,
+			},
+			side: NodeConfig {
+				contract: ContractConfig {
+					bin: include_str!("../../compiled_contracts/Side.bin")
+						.from_hex::<Vec<u8>>()
+						.unwrap()
+						.into(),
+				},
+				http: "http://localhost:8546".into(),
+				poll_interval: Duration::from_secs(1),
+				request_timeout: Duration::from_secs(5),
+				required_confirmations: 12,
+			},
+			authorities: Authorities {
+				accounts: vec![
+					"0000000000000000000000000000000000000001".parse().unwrap(),
+					"0000000000000000000000000000000000000002".parse().unwrap(),
+					"0000000000000000000000000000000000000003".parse().unwrap(),
+				],
+				required_signatures: 2,
+			},
+			estimated_gas_cost_of_withdraw: U256::from_dec_str("100000").unwrap(),
+			max_total_main_contract_balance: U256::from_dec_str("10000000000000000000").unwrap(),
+			max_single_deposit_value: U256::from_dec_str("1000000000000000000").unwrap(),
+		};
 
-        expected.txs.main_deploy = TransactionConfig {
-            gas: 20.into(),
-            gas_price: 0.into(),
-        };
+		expected.txs.main_deploy = TransactionConfig {
+			gas: 20.into(),
+			gas_price: 0.into(),
+		};
 
-        let config = Config::load_from_str(toml).unwrap();
-        assert_eq!(expected, config);
-    }
+		let config = Config::load_from_str(toml).unwrap();
+		assert_eq!(expected, config);
+	}
 
-    #[test]
-    fn load_minimal_setup_from_str() {
-        let toml = r#"
+	#[test]
+	fn load_minimal_setup_from_str() {
+		let toml = r#"
 address = "0x0000000000000000000000000000000000000001"
 estimated_gas_cost_of_withdraw = "200000000"
 max_total_main_contract_balance = "10000000000000000000"
@@ -362,47 +362,47 @@ accounts = [
 ]
 required_signatures = 2
 "#;
-        let expected = Config {
-            address: "0000000000000000000000000000000000000001".parse().unwrap(),
-            txs: Transactions::default(),
-            main: NodeConfig {
-                http: "".into(),
-                contract: ContractConfig {
-                    bin: include_str!("../../compiled_contracts/Main.bin")
-                        .from_hex::<Vec<u8>>()
-                        .unwrap()
-                        .into(),
-                },
-                poll_interval: Duration::from_secs(1),
-                request_timeout: Duration::from_secs(5),
-                required_confirmations: 12,
-            },
-            side: NodeConfig {
-                http: "".into(),
-                contract: ContractConfig {
-                    bin: include_str!("../../compiled_contracts/Side.bin")
-                        .from_hex::<Vec<u8>>()
-                        .unwrap()
-                        .into(),
-                },
-                poll_interval: Duration::from_secs(1),
-                request_timeout: Duration::from_secs(5),
-                required_confirmations: 12,
-            },
-            authorities: Authorities {
-                accounts: vec![
-                    "0000000000000000000000000000000000000001".parse().unwrap(),
-                    "0000000000000000000000000000000000000002".parse().unwrap(),
-                    "0000000000000000000000000000000000000003".parse().unwrap(),
-                ],
-                required_signatures: 2,
-            },
-            estimated_gas_cost_of_withdraw: U256::from_dec_str("200000000").unwrap(),
-            max_total_main_contract_balance: U256::from_dec_str("10000000000000000000").unwrap(),
-            max_single_deposit_value: U256::from_dec_str("1000000000000000000").unwrap(),
-        };
+		let expected = Config {
+			address: "0000000000000000000000000000000000000001".parse().unwrap(),
+			txs: Transactions::default(),
+			main: NodeConfig {
+				http: "".into(),
+				contract: ContractConfig {
+					bin: include_str!("../../compiled_contracts/Main.bin")
+						.from_hex::<Vec<u8>>()
+						.unwrap()
+						.into(),
+				},
+				poll_interval: Duration::from_secs(1),
+				request_timeout: Duration::from_secs(5),
+				required_confirmations: 12,
+			},
+			side: NodeConfig {
+				http: "".into(),
+				contract: ContractConfig {
+					bin: include_str!("../../compiled_contracts/Side.bin")
+						.from_hex::<Vec<u8>>()
+						.unwrap()
+						.into(),
+				},
+				poll_interval: Duration::from_secs(1),
+				request_timeout: Duration::from_secs(5),
+				required_confirmations: 12,
+			},
+			authorities: Authorities {
+				accounts: vec![
+					"0000000000000000000000000000000000000001".parse().unwrap(),
+					"0000000000000000000000000000000000000002".parse().unwrap(),
+					"0000000000000000000000000000000000000003".parse().unwrap(),
+				],
+				required_signatures: 2,
+			},
+			estimated_gas_cost_of_withdraw: U256::from_dec_str("200000000").unwrap(),
+			max_total_main_contract_balance: U256::from_dec_str("10000000000000000000").unwrap(),
+			max_single_deposit_value: U256::from_dec_str("1000000000000000000").unwrap(),
+		};
 
-        let config = Config::load_from_str(toml).unwrap();
-        assert_eq!(expected, config);
-    }
+		let config = Config::load_from_str(toml).unwrap();
+		assert_eq!(expected, config);
+	}
 }

--- a/bridge/src/database.rs
+++ b/bridge/src/database.rs
@@ -27,121 +27,121 @@ use web3::types::{Address, TransactionReceipt};
 /// bridge process state
 #[derive(Debug, PartialEq, Deserialize, Serialize, Default, Clone)]
 pub struct State {
-    /// Address of home contract.
-    pub main_contract_address: Address,
-    /// Address of foreign contract.
-    pub side_contract_address: Address,
-    /// Number of block at which home contract has been deployed.
-    pub main_deployed_at_block: u64,
-    /// Number of block at which foreign contract has been deployed.
-    pub side_deployed_at_block: u64,
-    /// Number of last block which has been checked for deposit relays.
-    pub last_main_to_side_sign_at_block: u64,
-    /// Number of last block which has been checked for withdraw relays.
-    pub last_side_to_main_signatures_at_block: u64,
-    /// Number of last block which has been checked for withdraw confirms.
-    pub last_side_to_main_sign_at_block: u64,
+	/// Address of home contract.
+	pub main_contract_address: Address,
+	/// Address of foreign contract.
+	pub side_contract_address: Address,
+	/// Number of block at which home contract has been deployed.
+	pub main_deployed_at_block: u64,
+	/// Number of block at which foreign contract has been deployed.
+	pub side_deployed_at_block: u64,
+	/// Number of last block which has been checked for deposit relays.
+	pub last_main_to_side_sign_at_block: u64,
+	/// Number of last block which has been checked for withdraw relays.
+	pub last_side_to_main_signatures_at_block: u64,
+	/// Number of last block which has been checked for withdraw confirms.
+	pub last_side_to_main_sign_at_block: u64,
 }
 
 impl State {
-    /// creates initial state for the bridge processes
-    /// from transaction receipts of contract deployments
-    pub fn from_transaction_receipts(
-        main_contract_deployment_receipt: &TransactionReceipt,
-        side_contract_deployment_receipt: &TransactionReceipt,
-    ) -> Self {
-        let main_block_number = main_contract_deployment_receipt
-            .block_number
-            .expect("main contract creation receipt must have a block number; qed")
-            .as_u64();
+	/// creates initial state for the bridge processes
+	/// from transaction receipts of contract deployments
+	pub fn from_transaction_receipts(
+		main_contract_deployment_receipt: &TransactionReceipt,
+		side_contract_deployment_receipt: &TransactionReceipt,
+	) -> Self {
+		let main_block_number = main_contract_deployment_receipt
+			.block_number
+			.expect("main contract creation receipt must have a block number; qed")
+			.as_u64();
 
-        let side_block_number = side_contract_deployment_receipt
-            .block_number
-            .expect("main contract creation receipt must have a block number; qed")
-            .as_u64();
+		let side_block_number = side_contract_deployment_receipt
+			.block_number
+			.expect("main contract creation receipt must have a block number; qed")
+			.as_u64();
 
-        Self {
-            main_contract_address: main_contract_deployment_receipt
-                .contract_address
-                .expect("main contract creation receipt must have an address; qed"),
-            side_contract_address: side_contract_deployment_receipt
-                .contract_address
-                .expect("side contract creation receipt must have an address; qed"),
-            main_deployed_at_block: main_block_number,
-            side_deployed_at_block: side_block_number,
-            last_main_to_side_sign_at_block: main_block_number,
-            last_side_to_main_sign_at_block: side_block_number,
-            last_side_to_main_signatures_at_block: side_block_number,
-        }
-    }
+		Self {
+			main_contract_address: main_contract_deployment_receipt
+				.contract_address
+				.expect("main contract creation receipt must have an address; qed"),
+			side_contract_address: side_contract_deployment_receipt
+				.contract_address
+				.expect("side contract creation receipt must have an address; qed"),
+			main_deployed_at_block: main_block_number,
+			side_deployed_at_block: side_block_number,
+			last_main_to_side_sign_at_block: main_block_number,
+			last_side_to_main_sign_at_block: side_block_number,
+			last_side_to_main_signatures_at_block: side_block_number,
+		}
+	}
 }
 
 impl State {
-    /// write state to a `std::io::write`
-    pub fn write<W: Write>(&self, mut write: W) -> Result<(), Error> {
-        let serialized = toml::to_string(self).expect("serialization can't fail. q.e.d.");
-        write.write_all(serialized.as_bytes())?;
-        write.flush()?;
-        Ok(())
-    }
+	/// write state to a `std::io::write`
+	pub fn write<W: Write>(&self, mut write: W) -> Result<(), Error> {
+		let serialized = toml::to_string(self).expect("serialization can't fail. q.e.d.");
+		write.write_all(serialized.as_bytes())?;
+		write.flush()?;
+		Ok(())
+	}
 }
 
 impl fmt::Display for State {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&toml::to_string(self).expect("serialization can't fail; qed"))
-    }
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		f.write_str(&toml::to_string(self).expect("serialization can't fail; qed"))
+	}
 }
 
 /// persistence for a `State`
 pub trait Database {
-    fn read(&self) -> State;
-    /// persist `state` to the database
-    fn write(&mut self, state: &State) -> Result<(), Error>;
+	fn read(&self) -> State;
+	/// persist `state` to the database
+	fn write(&mut self, state: &State) -> Result<(), Error>;
 }
 
 /// `State` stored in a TOML file
 pub struct TomlFileDatabase {
-    filepath: PathBuf,
-    state: State,
+	filepath: PathBuf,
+	state: State,
 }
 
 impl TomlFileDatabase {
-    /// create `TomlFileDatabase` backed by file at `filepath`
-    pub fn from_path<P: AsRef<Path>>(filepath: P) -> Result<Self, Error> {
-        let mut file = match fs::File::open(&filepath) {
-            Ok(file) => file,
-            Err(ref err) if err.kind() == io::ErrorKind::NotFound => {
-                return Err(ErrorKind::MissingFile(format!("{:?}", filepath.as_ref())).into())
-            }
-            Err(err) => return Err(err).chain_err(|| "Cannot open database"),
-        };
+	/// create `TomlFileDatabase` backed by file at `filepath`
+	pub fn from_path<P: AsRef<Path>>(filepath: P) -> Result<Self, Error> {
+		let mut file = match fs::File::open(&filepath) {
+			Ok(file) => file,
+			Err(ref err) if err.kind() == io::ErrorKind::NotFound => {
+				return Err(ErrorKind::MissingFile(format!("{:?}", filepath.as_ref())).into())
+			}
+			Err(err) => return Err(err).chain_err(|| "Cannot open database"),
+		};
 
-        let mut buffer = String::new();
-        file.read_to_string(&mut buffer)?;
-        let state: State = toml::from_str(&buffer).chain_err(|| "Cannot parse database")?;
-        Ok(Self {
-            filepath: filepath.as_ref().to_path_buf(),
-            state,
-        })
-    }
+		let mut buffer = String::new();
+		file.read_to_string(&mut buffer)?;
+		let state: State = toml::from_str(&buffer).chain_err(|| "Cannot parse database")?;
+		Ok(Self {
+			filepath: filepath.as_ref().to_path_buf(),
+			state,
+		})
+	}
 }
 
 impl Database for TomlFileDatabase {
-    fn read(&self) -> State {
-        self.state.clone()
-    }
+	fn read(&self) -> State {
+		self.state.clone()
+	}
 
-    fn write(&mut self, state: &State) -> Result<(), Error> {
-        if self.state != *state {
-            self.state = state.clone();
+	fn write(&mut self, state: &State) -> Result<(), Error> {
+		if self.state != *state {
+			self.state = state.clone();
 
-            let file = fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .open(&self.filepath)?;
+			let file = fs::OpenOptions::new()
+				.write(true)
+				.create(true)
+				.open(&self.filepath)?;
 
-            self.state.write(file)?;
-        }
-        Ok(())
-    }
+			self.state.write(file)?;
+		}
+		Ok(())
+	}
 }

--- a/bridge/src/deploy.rs
+++ b/bridge/src/deploy.rs
@@ -30,286 +30,286 @@ use web3::types::{TransactionReceipt, TransactionRequest};
 use web3::Transport;
 
 pub enum DeployState<T: Transport + Clone> {
-    NotDeployed,
-    Deploying {
-        data: Vec<u8>,
-        future: SendTransactionWithReceipt<T>,
-    },
-    Deployed {
-        contract: DeployedContract,
-    },
+	NotDeployed,
+	Deploying {
+		data: Vec<u8>,
+		future: SendTransactionWithReceipt<T>,
+	},
+	Deployed {
+		contract: DeployedContract,
+	},
 }
 
 pub struct DeployMain<T: Transport + Clone> {
-    config: Config,
-    main_transport: T,
-    state: DeployState<T>,
+	config: Config,
+	main_transport: T,
+	state: DeployState<T>,
 }
 
 impl<T: Transport + Clone> DeployMain<T> {
-    pub fn new(config: Config, main_transport: T) -> Self {
-        Self {
-            config,
-            main_transport,
-            state: DeployState::NotDeployed,
-        }
-    }
+	pub fn new(config: Config, main_transport: T) -> Self {
+		Self {
+			config,
+			main_transport,
+			state: DeployState::NotDeployed,
+		}
+	}
 }
 
 impl<T: Transport + Clone> Future for DeployMain<T> {
-    type Item = DeployedContract;
-    type Error = error::Error;
+	type Item = DeployedContract;
+	type Error = error::Error;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        loop {
-            let next_state = match self.state {
-                DeployState::Deployed { ref contract } => return Ok(contract.clone().into()),
-                DeployState::NotDeployed => {
-                    let data = contracts::main::constructor(
-                        self.config.main.contract.bin.clone().0,
-                        self.config.authorities.required_signatures,
-                        self.config.authorities.accounts.clone(),
-                    );
+	fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+		loop {
+			let next_state = match self.state {
+				DeployState::Deployed { ref contract } => return Ok(contract.clone().into()),
+				DeployState::NotDeployed => {
+					let data = contracts::main::constructor(
+						self.config.main.contract.bin.clone().0,
+						self.config.authorities.required_signatures,
+						self.config.authorities.accounts.clone(),
+					);
 
-                    let tx_request = TransactionRequest {
-                        from: self.config.address,
-                        to: None,
-                        gas: Some(self.config.txs.main_deploy.gas.into()),
-                        gas_price: Some(self.config.txs.main_deploy.gas_price.into()),
-                        value: None,
-                        data: Some(data.clone().into()),
-                        nonce: None,
-                        condition: None,
-                    };
+					let tx_request = TransactionRequest {
+						from: self.config.address,
+						to: None,
+						gas: Some(self.config.txs.main_deploy.gas.into()),
+						gas_price: Some(self.config.txs.main_deploy.gas_price.into()),
+						value: None,
+						data: Some(data.clone().into()),
+						nonce: None,
+						condition: None,
+					};
 
-                    let future =
-                        SendTransactionWithReceipt::new(SendTransactionWithReceiptOptions {
-                            transport: self.main_transport.clone(),
-                            request_timeout: self.config.main.request_timeout,
-                            poll_interval: self.config.main.poll_interval,
-                            confirmations: self.config.main.required_confirmations,
-                            transaction: tx_request,
-                        });
+					let future =
+						SendTransactionWithReceipt::new(SendTransactionWithReceiptOptions {
+							transport: self.main_transport.clone(),
+							request_timeout: self.config.main.request_timeout,
+							poll_interval: self.config.main.poll_interval,
+							confirmations: self.config.main.required_confirmations,
+							transaction: tx_request,
+						});
 
-                    info!("sending MainBridge contract deployment transaction and waiting for {} confirmations...", self.config.main.required_confirmations);
+					info!("sending MainBridge contract deployment transaction and waiting for {} confirmations...", self.config.main.required_confirmations);
 
-                    DeployState::Deploying { data, future }
-                }
-                DeployState::Deploying {
-                    ref mut future,
-                    ref data,
-                } => {
-                    let receipt = try_ready!(future
-                        .poll()
-                        .chain_err(|| "DeployMain: deployment transaction failed"));
-                    let address = receipt
-                        .contract_address
-                        .expect("contract creation receipt must have an address; qed");
-                    info!("MainBridge deployment completed to {:?}", address);
+					DeployState::Deploying { data, future }
+				}
+				DeployState::Deploying {
+					ref mut future,
+					ref data,
+				} => {
+					let receipt = try_ready!(future
+						.poll()
+						.chain_err(|| "DeployMain: deployment transaction failed"));
+					let address = receipt
+						.contract_address
+						.expect("contract creation receipt must have an address; qed");
+					info!("MainBridge deployment completed to {:?}", address);
 
-                    DeployState::Deployed {
-                        contract: DeployedContract::new(
-                            "Main".into(),
-                            include_str!("../../arbitrary/contracts/bridge.sol").into(),
-                            include_str!("../../compiled_contracts/Main.abi").into(),
-                            include_str!("../../compiled_contracts/Main.bin").into(),
-                            data.to_hex(),
-                            receipt,
-                        ),
-                    }
-                }
-            };
+					DeployState::Deployed {
+						contract: DeployedContract::new(
+							"Main".into(),
+							include_str!("../../arbitrary/contracts/bridge.sol").into(),
+							include_str!("../../compiled_contracts/Main.abi").into(),
+							include_str!("../../compiled_contracts/Main.bin").into(),
+							data.to_hex(),
+							receipt,
+						),
+					}
+				}
+			};
 
-            self.state = next_state;
-        }
-    }
+			self.state = next_state;
+		}
+	}
 }
 
 pub struct DeploySide<T: Transport + Clone> {
-    config: Config,
-    side_transport: T,
-    state: DeployState<T>,
+	config: Config,
+	side_transport: T,
+	state: DeployState<T>,
 }
 
 impl<T: Transport + Clone> DeploySide<T> {
-    pub fn new(config: Config, side_transport: T) -> Self {
-        Self {
-            config,
-            side_transport,
-            state: DeployState::NotDeployed,
-        }
-    }
+	pub fn new(config: Config, side_transport: T) -> Self {
+		Self {
+			config,
+			side_transport,
+			state: DeployState::NotDeployed,
+		}
+	}
 }
 
 impl<T: Transport + Clone> Future for DeploySide<T> {
-    type Item = DeployedContract;
-    type Error = error::Error;
+	type Item = DeployedContract;
+	type Error = error::Error;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        loop {
-            let next_state = match self.state {
-                DeployState::Deployed { ref contract } => return Ok(contract.clone().into()),
-                DeployState::NotDeployed => {
-                    let data = contracts::side::constructor(
-                        self.config.side.contract.bin.clone().0,
-                        self.config.authorities.required_signatures,
-                        self.config.authorities.accounts.clone(),
-                    );
+	fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+		loop {
+			let next_state = match self.state {
+				DeployState::Deployed { ref contract } => return Ok(contract.clone().into()),
+				DeployState::NotDeployed => {
+					let data = contracts::side::constructor(
+						self.config.side.contract.bin.clone().0,
+						self.config.authorities.required_signatures,
+						self.config.authorities.accounts.clone(),
+					);
 
-                    let tx_request = TransactionRequest {
-                        from: self.config.address,
-                        to: None,
-                        gas: Some(self.config.txs.side_deploy.gas.into()),
-                        gas_price: Some(self.config.txs.side_deploy.gas_price.into()),
-                        value: None,
-                        data: Some(data.clone().into()),
-                        nonce: None,
-                        condition: None,
-                    };
+					let tx_request = TransactionRequest {
+						from: self.config.address,
+						to: None,
+						gas: Some(self.config.txs.side_deploy.gas.into()),
+						gas_price: Some(self.config.txs.side_deploy.gas_price.into()),
+						value: None,
+						data: Some(data.clone().into()),
+						nonce: None,
+						condition: None,
+					};
 
-                    let future =
-                        SendTransactionWithReceipt::new(SendTransactionWithReceiptOptions {
-                            transport: self.side_transport.clone(),
-                            request_timeout: self.config.side.request_timeout,
-                            poll_interval: self.config.side.poll_interval,
-                            confirmations: self.config.side.required_confirmations,
-                            transaction: tx_request,
-                        });
+					let future =
+						SendTransactionWithReceipt::new(SendTransactionWithReceiptOptions {
+							transport: self.side_transport.clone(),
+							request_timeout: self.config.side.request_timeout,
+							poll_interval: self.config.side.poll_interval,
+							confirmations: self.config.side.required_confirmations,
+							transaction: tx_request,
+						});
 
-                    info!("sending SideBridge contract deployment transaction and waiting for {} confirmations...", self.config.side.required_confirmations);
+					info!("sending SideBridge contract deployment transaction and waiting for {} confirmations...", self.config.side.required_confirmations);
 
-                    DeployState::Deploying { data, future }
-                }
-                DeployState::Deploying {
-                    ref mut future,
-                    ref data,
-                } => {
-                    let receipt = try_ready!(future
-                        .poll()
-                        .chain_err(|| "DeploySide: deployment transaction failed"));
-                    let address = receipt
-                        .contract_address
-                        .expect("contract creation receipt must have an address; qed");
-                    info!("SideBridge deployment completed to {:?}", address);
+					DeployState::Deploying { data, future }
+				}
+				DeployState::Deploying {
+					ref mut future,
+					ref data,
+				} => {
+					let receipt = try_ready!(future
+						.poll()
+						.chain_err(|| "DeploySide: deployment transaction failed"));
+					let address = receipt
+						.contract_address
+						.expect("contract creation receipt must have an address; qed");
+					info!("SideBridge deployment completed to {:?}", address);
 
-                    DeployState::Deployed {
-                        contract: DeployedContract::new(
-                            "SideBridge".into(),
-                            include_str!("../../arbitrary/contracts/bridge.sol").into(),
-                            include_str!("../../compiled_contracts/Side.abi").into(),
-                            include_str!("../../compiled_contracts/Side.bin").into(),
-                            data.to_hex(),
-                            receipt,
-                        ),
-                    }
-                }
-            };
+					DeployState::Deployed {
+						contract: DeployedContract::new(
+							"SideBridge".into(),
+							include_str!("../../arbitrary/contracts/bridge.sol").into(),
+							include_str!("../../compiled_contracts/Side.abi").into(),
+							include_str!("../../compiled_contracts/Side.bin").into(),
+							data.to_hex(),
+							receipt,
+						),
+					}
+				}
+			};
 
-            self.state = next_state;
-        }
-    }
+			self.state = next_state;
+		}
+	}
 }
 
 #[derive(Clone)]
 pub struct DeployedContract {
-    pub contract_name: String,
-    pub contract_address: String,
-    pub contract_source: String,
-    pub abi: String,
-    pub bytecode_hex: String,
-    pub contract_creation_code_hex: String,
-    pub receipt: TransactionReceipt,
+	pub contract_name: String,
+	pub contract_address: String,
+	pub contract_source: String,
+	pub abi: String,
+	pub bytecode_hex: String,
+	pub contract_creation_code_hex: String,
+	pub receipt: TransactionReceipt,
 }
 
 impl DeployedContract {
-    pub fn new(
-        contract_name: String,
-        contract_source: String,
-        abi: String,
-        bytecode_hex: String,
-        contract_creation_code_hex: String,
-        receipt: TransactionReceipt,
-    ) -> Self {
-        assert_eq!(
-            bytecode_hex,
-            &contract_creation_code_hex[..bytecode_hex.len()],
-            "deployed byte code is contract bytecode followed by constructor args; qed"
-        );
+	pub fn new(
+		contract_name: String,
+		contract_source: String,
+		abi: String,
+		bytecode_hex: String,
+		contract_creation_code_hex: String,
+		receipt: TransactionReceipt,
+	) -> Self {
+		assert_eq!(
+			bytecode_hex,
+			&contract_creation_code_hex[..bytecode_hex.len()],
+			"deployed byte code is contract bytecode followed by constructor args; qed"
+		);
 
-        Self {
-            contract_name,
-            contract_address: format!(
-                "{:x}",
-                receipt
-                    .contract_address
-                    .expect("contract creation receipt must have an address; qed")
-            ),
-            contract_source,
-            abi,
-            bytecode_hex,
-            contract_creation_code_hex,
-            receipt,
-        }
-    }
+		Self {
+			contract_name,
+			contract_address: format!(
+				"{:x}",
+				receipt
+					.contract_address
+					.expect("contract creation receipt must have an address; qed")
+			),
+			contract_source,
+			abi,
+			bytecode_hex,
+			contract_creation_code_hex,
+			receipt,
+		}
+	}
 
-    /// writes useful information about the deployment into `dir`.
-    /// REMOVES `dir` if it already exists!
-    /// helps with troubleshooting and verification (https://ropsten.etherscan.io/verifyContract)
-    /// of deployments.
-    /// information includes:
-    /// - solc version used
-    /// - git commit
-    /// - contract source code
-    /// - contract address
-    /// - hash of transaction the contract got deployed in
-    /// - contract byte code
-    /// - input data for contract creation transaction
-    /// - ...
-    pub fn dump_info<P: AsRef<Path>>(&self, dir: P) -> Result<(), error::Error> {
-        let dir = dir.as_ref();
+	/// writes useful information about the deployment into `dir`.
+	/// REMOVES `dir` if it already exists!
+	/// helps with troubleshooting and verification (https://ropsten.etherscan.io/verifyContract)
+	/// of deployments.
+	/// information includes:
+	/// - solc version used
+	/// - git commit
+	/// - contract source code
+	/// - contract address
+	/// - hash of transaction the contract got deployed in
+	/// - contract byte code
+	/// - input data for contract creation transaction
+	/// - ...
+	pub fn dump_info<P: AsRef<Path>>(&self, dir: P) -> Result<(), error::Error> {
+		let dir = dir.as_ref();
 
-        if Path::new(dir).exists() {
-            info!("{:?} exists. removing", dir);
-            fs::remove_dir_all(dir)?;
-        }
-        fs::create_dir(dir)?;
-        info!("{:?} created", dir);
+		if Path::new(dir).exists() {
+			info!("{:?} exists. removing", dir);
+			fs::remove_dir_all(dir)?;
+		}
+		fs::create_dir(dir)?;
+		info!("{:?} created", dir);
 
-        let mut file = File::create(dir.join("bridge_version"))?;
-        file.write_all(env!("CARGO_PKG_VERSION").as_bytes())?;
+		let mut file = File::create(dir.join("bridge_version"))?;
+		file.write_all(env!("CARGO_PKG_VERSION").as_bytes())?;
 
-        let mut file = File::create(dir.join("commit_hash"))?;
-        file.write_all(env!("GIT_HASH").as_bytes())?;
+		let mut file = File::create(dir.join("commit_hash"))?;
+		file.write_all(env!("GIT_HASH").as_bytes())?;
 
-        let mut file = File::create(dir.join("compiler"))?;
-        file.write_all(env!("SOLC_VERSION").as_bytes())?;
+		let mut file = File::create(dir.join("compiler"))?;
+		file.write_all(env!("SOLC_VERSION").as_bytes())?;
 
-        let mut file = File::create(dir.join("optimization"))?;
-        file.write_all("yes".as_bytes())?;
+		let mut file = File::create(dir.join("optimization"))?;
+		file.write_all("yes".as_bytes())?;
 
-        let mut file = File::create(dir.join("contract_name"))?;
-        file.write_all(self.contract_name.as_bytes())?;
+		let mut file = File::create(dir.join("contract_name"))?;
+		file.write_all(self.contract_name.as_bytes())?;
 
-        let mut file = File::create(dir.join("contract_address"))?;
-        file.write_all(self.contract_address.as_bytes())?;
+		let mut file = File::create(dir.join("contract_address"))?;
+		file.write_all(self.contract_address.as_bytes())?;
 
-        let mut file = File::create(dir.join("contract_source.sol"))?;
-        file.write_all(self.contract_source.as_bytes())?;
+		let mut file = File::create(dir.join("contract_source.sol"))?;
+		file.write_all(self.contract_source.as_bytes())?;
 
-        let mut file = File::create(dir.join("transaction_hash"))?;
-        file.write_all(format!("{:x}", self.receipt.transaction_hash).as_bytes())?;
+		let mut file = File::create(dir.join("transaction_hash"))?;
+		file.write_all(format!("{:x}", self.receipt.transaction_hash).as_bytes())?;
 
-        let mut file = File::create(dir.join("deployed_bytecode"))?;
-        file.write_all(self.bytecode_hex.as_bytes())?;
+		let mut file = File::create(dir.join("deployed_bytecode"))?;
+		file.write_all(self.bytecode_hex.as_bytes())?;
 
-        let constructor_arguments_bytecode =
-            &self.contract_creation_code_hex[self.bytecode_hex.len()..];
+		let constructor_arguments_bytecode =
+			&self.contract_creation_code_hex[self.bytecode_hex.len()..];
 
-        let mut file = File::create(dir.join("constructor_arguments_bytecode"))?;
-        file.write_all(constructor_arguments_bytecode.as_bytes())?;
+		let mut file = File::create(dir.join("constructor_arguments_bytecode"))?;
+		file.write_all(constructor_arguments_bytecode.as_bytes())?;
 
-        File::create(dir.join("abi"))?.write_all(self.abi.as_bytes())?;
+		File::create(dir.join("abi"))?.write_all(self.abi.as_bytes())?;
 
-        Ok(())
-    }
+		Ok(())
+	}
 }

--- a/bridge/src/error.rs
+++ b/bridge/src/error.rs
@@ -21,35 +21,35 @@ use tokio_timer::{TimeoutError, TimerError};
 use {ethabi, rustc_hex, toml, web3};
 
 error_chain! {
-    types {
-        Error, ErrorKind, ResultExt, Result;
-    }
+	types {
+		Error, ErrorKind, ResultExt, Result;
+	}
 
-    foreign_links {
-        Io(io::Error);
-        Toml(toml::de::Error);
-        Ethabi(ethabi::Error);
-        Timer(TimerError);
-        Hex(rustc_hex::FromHexError);
-    }
+	foreign_links {
+		Io(io::Error);
+		Toml(toml::de::Error);
+		Ethabi(ethabi::Error);
+		Timer(TimerError);
+		Hex(rustc_hex::FromHexError);
+	}
 
-    errors {
-        TimedOut {
-            description("Request timed out"),
-            display("Request timed out"),
-        }
-        // workaround for error_chain not allowing to check internal error kind
-        // https://github.com/rust-lang-nursery/error-chain/issues/206
-        MissingFile(filename: String) {
-            description("File not found"),
-            display("File {} not found", filename),
-        }
-        // workaround for lack of web3:Error Display and Error implementations
-        Web3(err: web3::Error) {
-            description("web3 error"),
-            display("{:?}", err),
-        }
-    }
+	errors {
+		TimedOut {
+			description("Request timed out"),
+			display("Request timed out"),
+		}
+		// workaround for error_chain not allowing to check internal error kind
+		// https://github.com/rust-lang-nursery/error-chain/issues/206
+		MissingFile(filename: String) {
+			description("File not found"),
+			display("File {} not found", filename),
+		}
+		// workaround for lack of web3:Error Display and Error implementations
+		Web3(err: web3::Error) {
+			description("web3 error"),
+			display("{:?}", err),
+		}
+	}
 }
 
 // tokio timer `Timeout<F>` can only wrap futures `F` whose assocaited `Error` type
@@ -66,16 +66,16 @@ error_chain! {
 // with `Timeout`.
 
 impl<F> From<TimeoutError<F>> for Error {
-    fn from(err: TimeoutError<F>) -> Self {
-        match err {
-            TimeoutError::Timer(_, timer_error) => timer_error.into(),
-            TimeoutError::TimedOut(_) => ErrorKind::TimedOut.into(),
-        }
-    }
+	fn from(err: TimeoutError<F>) -> Self {
+		match err {
+			TimeoutError::Timer(_, timer_error) => timer_error.into(),
+			TimeoutError::TimedOut(_) => ErrorKind::TimedOut.into(),
+		}
+	}
 }
 
 impl From<web3::Error> for Error {
-    fn from(err: web3::Error) -> Self {
-        ErrorKind::Web3(err).into()
-    }
+	fn from(err: web3::Error) -> Self {
+		ErrorKind::Web3(err).into()
+	}
 }

--- a/bridge/src/helpers.rs
+++ b/bridge/src/helpers.rs
@@ -31,108 +31,108 @@ use web3::{self, Transport};
 
 /// attempts to convert a raw `web3_log` into the ethabi log type of a specific `event`
 pub fn parse_log<T: Fn(RawLog) -> ethabi::Result<L>, L>(
-    parse: T,
-    web3_log: &web3::types::Log,
+	parse: T,
+	web3_log: &web3::types::Log,
 ) -> ethabi::Result<L> {
-    let ethabi_log = RawLog {
-        topics: web3_log.topics.iter().map(|t| t.0.into()).collect(),
-        data: web3_log.data.0.clone(),
-    };
-    parse(ethabi_log)
+	let ethabi_log = RawLog {
+		topics: web3_log.topics.iter().map(|t| t.0.into()).collect(),
+		data: web3_log.data.0.clone(),
+	};
+	parse(ethabi_log)
 }
 
 /// use `AsyncCall::new(transport, contract_address, timeout, output_decoder)` to
 /// get a `Future` that resolves with the decoded output from calling `function`
 /// on `contract_address`.
 pub struct AsyncCall<T: Transport, F: FunctionOutputDecoder> {
-    future: Timeout<FromErr<CallFuture<Bytes, T::Out>, error::Error>>,
-    output_decoder: F,
+	future: Timeout<FromErr<CallFuture<Bytes, T::Out>, error::Error>>,
+	output_decoder: F,
 }
 
 impl<T: Transport, F: FunctionOutputDecoder> AsyncCall<T, F> {
-    /// call `function` at `contract_address`.
-    /// returns a `Future` that resolves with the decoded output of `function`.
-    pub fn new(
-        transport: &T,
-        contract_address: Address,
-        timeout: Duration,
-        payload: Vec<u8>,
-        output_decoder: F,
-    ) -> Self {
-        let request = CallRequest {
-            from: None,
-            to: contract_address,
-            gas: None,
-            gas_price: None,
-            value: None,
-            data: Some(Bytes(payload)),
-        };
-        let inner_future = web3::api::Eth::new(transport)
-            .call(request, None)
-            .from_err();
-        let future = Timer::default().timeout(inner_future, timeout);
-        Self {
-            future,
-            output_decoder,
-        }
-    }
+	/// call `function` at `contract_address`.
+	/// returns a `Future` that resolves with the decoded output of `function`.
+	pub fn new(
+		transport: &T,
+		contract_address: Address,
+		timeout: Duration,
+		payload: Vec<u8>,
+		output_decoder: F,
+	) -> Self {
+		let request = CallRequest {
+			from: None,
+			to: contract_address,
+			gas: None,
+			gas_price: None,
+			value: None,
+			data: Some(Bytes(payload)),
+		};
+		let inner_future = web3::api::Eth::new(transport)
+			.call(request, None)
+			.from_err();
+		let future = Timer::default().timeout(inner_future, timeout);
+		Self {
+			future,
+			output_decoder,
+		}
+	}
 }
 
 impl<T: Transport, F: FunctionOutputDecoder> Future for AsyncCall<T, F> {
-    type Item = F::Output;
-    type Error = error::Error;
+	type Item = F::Output;
+	type Error = error::Error;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        let encoded = try_ready!(self
-            .future
-            .poll()
-            .chain_err(|| "failed to poll inner web3 CallFuture future"));
-        let decoded = self
-            .output_decoder
-            .decode(&encoded.0)
-            .chain_err(|| format!("failed to decode response {:?}", encoded))?;
-        Ok(Async::Ready(decoded))
-    }
+	fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+		let encoded = try_ready!(self
+			.future
+			.poll()
+			.chain_err(|| "failed to poll inner web3 CallFuture future"));
+		let decoded = self
+			.output_decoder
+			.decode(&encoded.0)
+			.chain_err(|| format!("failed to decode response {:?}", encoded))?;
+		Ok(Async::Ready(decoded))
+	}
 }
 
 pub struct AsyncTransaction<T: Transport> {
-    future: Timeout<FromErr<CallFuture<H256, T::Out>, error::Error>>,
+	future: Timeout<FromErr<CallFuture<H256, T::Out>, error::Error>>,
 }
 
 impl<T: Transport> AsyncTransaction<T> {
-    pub fn new(
-        transport: &T,
-        contract_address: Address,
-        authority_address: Address,
-        gas: U256,
-        gas_price: U256,
-        timeout: Duration,
-        payload: Vec<u8>,
-    ) -> Self {
-        let request = TransactionRequest {
-            from: authority_address,
-            to: Some(contract_address),
-            gas: Some(gas),
-            gas_price: Some(gas_price),
-            value: None,
-            data: Some(Bytes(payload)),
-            nonce: None,
-            condition: None,
-        };
-        let inner_future = web3::api::Eth::new(transport)
-            .send_transaction(request)
-            .from_err();
-        let future = Timer::default().timeout(inner_future, timeout);
-        Self { future }
-    }
+	pub fn new(
+		transport: &T,
+		contract_address: Address,
+		authority_address: Address,
+		gas: U256,
+		gas_price: U256,
+		timeout: Duration,
+		payload: Vec<u8>,
+	) -> Self {
+		let request = TransactionRequest {
+			from: authority_address,
+			to: Some(contract_address),
+			gas: Some(gas),
+			gas_price: Some(gas_price),
+			value: None,
+			data: Some(Bytes(payload)),
+			nonce: None,
+			condition: None,
+		};
+		let inner_future = web3::api::Eth::new(transport)
+			.send_transaction(request)
+			.from_err();
+		let future = Timer::default().timeout(inner_future, timeout);
+		Self { future }
+	}
 }
 
 impl<T: Transport> Future for AsyncTransaction<T> {
-    type Item = H256;
-    type Error = error::Error;
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.future.poll().map_err(|x| x.into())
-    }
+	type Item = H256;
+	type Error = error::Error;
+	fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+		self.future.poll().map_err(|x| x.into())
+	}
 }
 
 /// the toml crate parses integer literals as `i64`.
@@ -142,101 +142,101 @@ impl<T: Transport> Future for AsyncTransaction<T> {
 /// deserializer and parse them as U256.
 pub fn deserialize_u256<'de, D>(deserializer: D) -> Result<U256, D::Error>
 where
-    D: Deserializer<'de>,
+	D: Deserializer<'de>,
 {
-    let s: &str = Deserialize::deserialize(deserializer)?;
-    U256::from_dec_str(s).map_err(|_| D::Error::custom("failed to parse U256 from dec str"))
+	let s: &str = Deserialize::deserialize(deserializer)?;
+	U256::from_dec_str(s).map_err(|_| D::Error::custom("failed to parse U256 from dec str"))
 }
 
 pub fn serialize_u256<S>(value: &U256, serializer: S) -> Result<S::Ok, S::Error>
 where
-    S: Serializer,
+	S: Serializer,
 {
-    serializer.serialize_str(&format!("{}", value))
+	serializer.serialize_str(&format!("{}", value))
 }
 
 /// extends the `Stream` trait by the `last` function
 pub trait StreamExt<I> {
-    /// if you're interested only in the last item in a stream
-    fn last(self) -> Last<Self, I>
-    where
-        Self: Sized;
+	/// if you're interested only in the last item in a stream
+	fn last(self) -> Last<Self, I>
+	where
+		Self: Sized;
 }
 
 impl<S, I> StreamExt<I> for S
 where
-    S: Stream,
+	S: Stream,
 {
-    fn last(self) -> Last<Self, I>
-    where
-        Self: Sized,
-    {
-        Last {
-            stream: self,
-            last: None,
-        }
-    }
+	fn last(self) -> Last<Self, I>
+	where
+		Self: Sized,
+	{
+		Last {
+			stream: self,
+			last: None,
+		}
+	}
 }
 
 /// `Future` that wraps a `Stream` and completes with the last
 /// item in the stream once the stream is over.
 pub struct Last<S, I> {
-    stream: S,
-    last: Option<I>,
+	stream: S,
+	last: Option<I>,
 }
 
 impl<S, I> Future for Last<S, I>
 where
-    S: Stream<Item = I>,
+	S: Stream<Item = I>,
 {
-    type Item = Option<I>;
-    type Error = S::Error;
+	type Item = Option<I>;
+	type Error = S::Error;
 
-    fn poll(&mut self) -> Poll<Self::Item, S::Error> {
-        loop {
-            match self.stream.poll() {
-                Err(err) => return Err(err),
-                Ok(Async::NotReady) => return Ok(Async::NotReady),
-                // stream is finished
-                Ok(Async::Ready(None)) => return Ok(Async::Ready(self.last.take())),
-                // there is more
-                Ok(Async::Ready(item)) => self.last = item,
-            }
-        }
-    }
+	fn poll(&mut self) -> Poll<Self::Item, S::Error> {
+		loop {
+			match self.stream.poll() {
+				Err(err) => return Err(err),
+				Ok(Async::NotReady) => return Ok(Async::NotReady),
+				// stream is finished
+				Ok(Async::Ready(None)) => return Ok(Async::Ready(self.last.take())),
+				// there is more
+				Ok(Async::Ready(item)) => self.last = item,
+			}
+		}
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use futures;
-    use tokio_core::reactor::Core;
+	use super::*;
+	use futures;
+	use tokio_core::reactor::Core;
 
-    #[test]
-    fn test_stream_ext_last_empty() {
-        let stream = futures::stream::empty::<(), ()>();
-        let mut event_loop = Core::new().unwrap();
-        assert_eq!(event_loop.run(stream.last()).unwrap(), None);
-    }
+	#[test]
+	fn test_stream_ext_last_empty() {
+		let stream = futures::stream::empty::<(), ()>();
+		let mut event_loop = Core::new().unwrap();
+		assert_eq!(event_loop.run(stream.last()).unwrap(), None);
+	}
 
-    #[test]
-    fn test_stream_ext_last_once_ok() {
-        let stream = futures::stream::once::<u32, ()>(Ok(42));
-        let mut event_loop = Core::new().unwrap();
-        assert_eq!(event_loop.run(stream.last()).unwrap(), Some(42));
-    }
+	#[test]
+	fn test_stream_ext_last_once_ok() {
+		let stream = futures::stream::once::<u32, ()>(Ok(42));
+		let mut event_loop = Core::new().unwrap();
+		assert_eq!(event_loop.run(stream.last()).unwrap(), Some(42));
+	}
 
-    #[test]
-    fn test_stream_ext_last_once_err() {
-        let stream = futures::stream::once::<u32, u32>(Err(42));
-        let mut event_loop = Core::new().unwrap();
-        assert_eq!(event_loop.run(stream.last()).unwrap_err(), 42);
-    }
+	#[test]
+	fn test_stream_ext_last_once_err() {
+		let stream = futures::stream::once::<u32, u32>(Err(42));
+		let mut event_loop = Core::new().unwrap();
+		assert_eq!(event_loop.run(stream.last()).unwrap_err(), 42);
+	}
 
-    #[test]
-    fn test_stream_ext_last_three() {
-        let stream = futures::stream::iter_ok::<_, ()>(vec![17, 19, 3]);
-        let mut event_loop = Core::new().unwrap();
-        assert_eq!(event_loop.run(stream.last()).unwrap(), Some(3));
-    }
+	#[test]
+	fn test_stream_ext_last_three() {
+		let stream = futures::stream::iter_ok::<_, ()>(vec![17, 19, 3]);
+		let mut event_loop = Core::new().unwrap();
+		assert_eq!(event_loop.run(stream.last()).unwrap(), Some(3));
+	}
 }

--- a/bridge/src/log_stream.rs
+++ b/bridge/src/log_stream.rs
@@ -28,288 +28,288 @@ use web3::types::{Address, FilterBuilder, Log, H256};
 use web3::Transport;
 
 fn ethabi_topic_to_web3(topic: &ethabi::Topic<ethabi::Hash>) -> Option<Vec<H256>> {
-    match topic {
-        ethabi::Topic::Any => None,
-        ethabi::Topic::OneOf(options) => Some(options.clone()),
-        ethabi::Topic::This(hash) => Some(vec![hash.clone()]),
-    }
+	match topic {
+		ethabi::Topic::Any => None,
+		ethabi::Topic::OneOf(options) => Some(options.clone()),
+		ethabi::Topic::This(hash) => Some(vec![hash.clone()]),
+	}
 }
 
 fn filter_to_builder(filter: &ethabi::TopicFilter, address: Address) -> FilterBuilder {
-    let t0 = ethabi_topic_to_web3(&filter.topic0);
-    let t1 = ethabi_topic_to_web3(&filter.topic1);
-    let t2 = ethabi_topic_to_web3(&filter.topic2);
-    let t3 = ethabi_topic_to_web3(&filter.topic3);
-    FilterBuilder::default()
-        .address(vec![address])
-        .topics(t0, t1, t2, t3)
+	let t0 = ethabi_topic_to_web3(&filter.topic0);
+	let t1 = ethabi_topic_to_web3(&filter.topic1);
+	let t2 = ethabi_topic_to_web3(&filter.topic2);
+	let t3 = ethabi_topic_to_web3(&filter.topic3);
+	FilterBuilder::default()
+		.address(vec![address])
+		.topics(t0, t1, t2, t3)
 }
 
 /// options for creating a `LogStream`. passed to `LogStream::new`
 pub struct LogStreamOptions<T> {
-    pub filter: ethabi::TopicFilter,
-    pub request_timeout: Duration,
-    pub poll_interval: Duration,
-    pub confirmations: u32,
-    pub transport: T,
-    pub contract_address: Address,
-    pub after: u64,
+	pub filter: ethabi::TopicFilter,
+	pub request_timeout: Duration,
+	pub poll_interval: Duration,
+	pub confirmations: u32,
+	pub transport: T,
+	pub contract_address: Address,
+	pub after: u64,
 }
 
 /// Contains all logs matching `LogStream` filter in inclusive block range `[from, to]`.
 #[derive(Debug, PartialEq)]
 pub struct LogsInBlockRange {
-    pub from: u64,
-    pub to: u64,
-    pub logs: Vec<Log>,
+	pub from: u64,
+	pub to: u64,
+	pub logs: Vec<Log>,
 }
 
 /// Log Stream state.
 enum State<T: Transport> {
-    /// Fetching best block number.
-    AwaitBlockNumber,
-    /// Fetching logs for new best block.
-    AwaitLogs {
-        from: u64,
-        to: u64,
-        future: Timeout<FromErr<CallFuture<Vec<Log>, T::Out>, error::Error>>,
-    },
+	/// Fetching best block number.
+	AwaitBlockNumber,
+	/// Fetching logs for new best block.
+	AwaitLogs {
+		from: u64,
+		to: u64,
+		future: Timeout<FromErr<CallFuture<Vec<Log>, T::Out>, error::Error>>,
+	},
 }
 
 /// `Stream` that repeatedly polls logs matching `filter_builder` from `contract_address`
 /// with adjustable `poll_interval` and `request_timeout`.
 /// yields new logs that are `confirmations` blocks deep.
 pub struct LogStream<T: Transport> {
-    block_number_stream: BlockNumberStream<T>,
-    request_timeout: Duration,
-    transport: T,
-    last_checked_block: u64,
-    timer: Timer,
-    state: State<T>,
-    filter_builder: FilterBuilder,
-    topic: Vec<H256>,
+	block_number_stream: BlockNumberStream<T>,
+	request_timeout: Duration,
+	transport: T,
+	last_checked_block: u64,
+	timer: Timer,
+	state: State<T>,
+	filter_builder: FilterBuilder,
+	topic: Vec<H256>,
 }
 
 impl<T: Transport> LogStream<T> {
-    pub fn new(options: LogStreamOptions<T>) -> Self {
-        let timer = Timer::default();
+	pub fn new(options: LogStreamOptions<T>) -> Self {
+		let timer = Timer::default();
 
-        let topic = ethabi_topic_to_web3(&options.filter.topic0)
-            .expect("filter must have at least 1 topic. q.e.d.");
-        let filter_builder = filter_to_builder(&options.filter, options.contract_address);
+		let topic = ethabi_topic_to_web3(&options.filter.topic0)
+			.expect("filter must have at least 1 topic. q.e.d.");
+		let filter_builder = filter_to_builder(&options.filter, options.contract_address);
 
-        let block_number_stream_options = BlockNumberStreamOptions {
-            request_timeout: options.request_timeout,
-            poll_interval: options.poll_interval,
-            confirmations: options.confirmations,
-            transport: options.transport.clone(),
-            after: options.after,
-        };
+		let block_number_stream_options = BlockNumberStreamOptions {
+			request_timeout: options.request_timeout,
+			poll_interval: options.poll_interval,
+			confirmations: options.confirmations,
+			transport: options.transport.clone(),
+			after: options.after,
+		};
 
-        LogStream {
-            block_number_stream: BlockNumberStream::new(block_number_stream_options),
-            request_timeout: options.request_timeout,
-            transport: options.transport,
-            last_checked_block: options.after,
-            timer,
-            state: State::AwaitBlockNumber,
-            filter_builder,
-            topic,
-        }
-    }
+		LogStream {
+			block_number_stream: BlockNumberStream::new(block_number_stream_options),
+			request_timeout: options.request_timeout,
+			transport: options.transport,
+			last_checked_block: options.after,
+			timer,
+			state: State::AwaitBlockNumber,
+			filter_builder,
+			topic,
+		}
+	}
 }
 
 impl<T: Transport> Stream for LogStream<T> {
-    type Item = LogsInBlockRange;
-    type Error = error::Error;
+	type Item = LogsInBlockRange;
+	type Error = error::Error;
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        loop {
-            let (next_state, value_to_yield) = match self.state {
-                State::AwaitBlockNumber => {
-                    let last_block = try_stream!(self
-                        .block_number_stream
-                        .poll()
-                        .chain_err(|| "LogStream: fetching of last confirmed block number failed"));
-                    info!("LogStream: fetched confirmed block number {}", last_block);
+	fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+		loop {
+			let (next_state, value_to_yield) = match self.state {
+				State::AwaitBlockNumber => {
+					let last_block = try_stream!(self
+						.block_number_stream
+						.poll()
+						.chain_err(|| "LogStream: fetching of last confirmed block number failed"));
+					info!("LogStream: fetched confirmed block number {}", last_block);
 
-                    let from = self.last_checked_block + 1;
-                    let filter = self
-                        .filter_builder
-                        .clone()
-                        .from_block(from.into())
-                        .to_block(last_block.into())
-                        .build();
-                    let future = web3::api::Eth::new(&self.transport).logs(filter);
+					let from = self.last_checked_block + 1;
+					let filter = self
+						.filter_builder
+						.clone()
+						.from_block(from.into())
+						.to_block(last_block.into())
+						.build();
+					let future = web3::api::Eth::new(&self.transport).logs(filter);
 
-                    info!(
-                        "LogStream: fetching logs in blocks {} to {}",
-                        from, last_block
-                    );
+					info!(
+						"LogStream: fetching logs in blocks {} to {}",
+						from, last_block
+					);
 
-                    let next_state = State::AwaitLogs {
-                        from: from,
-                        to: last_block,
-                        future: self.timer.timeout(future.from_err(), self.request_timeout),
-                    };
+					let next_state = State::AwaitLogs {
+						from: from,
+						to: last_block,
+						future: self.timer.timeout(future.from_err(), self.request_timeout),
+					};
 
-                    (next_state, None)
-                }
-                State::AwaitLogs {
-                    ref mut future,
-                    from,
-                    to,
-                } => {
-                    let logs = try_ready!(future
-                        .poll()
-                        .chain_err(|| "LogStream: polling web3 logs failed"));
-                    info!(
-                        "LogStream (topic: {:?}): fetched {} logs from block {} to block {}",
-                        self.topic,
-                        logs.len(),
-                        from,
-                        to
-                    );
-                    let log_range_to_yield = LogsInBlockRange { from, to, logs };
+					(next_state, None)
+				}
+				State::AwaitLogs {
+					ref mut future,
+					from,
+					to,
+				} => {
+					let logs = try_ready!(future
+						.poll()
+						.chain_err(|| "LogStream: polling web3 logs failed"));
+					info!(
+						"LogStream (topic: {:?}): fetched {} logs from block {} to block {}",
+						self.topic,
+						logs.len(),
+						from,
+						to
+					);
+					let log_range_to_yield = LogsInBlockRange { from, to, logs };
 
-                    self.last_checked_block = to;
-                    (State::AwaitBlockNumber, Some(log_range_to_yield))
-                }
-            };
+					self.last_checked_block = to;
+					(State::AwaitBlockNumber, Some(log_range_to_yield))
+				}
+			};
 
-            self.state = next_state;
+			self.state = next_state;
 
-            if value_to_yield.is_some() {
-                return Ok(Async::Ready(value_to_yield));
-            }
-        }
-    }
+			if value_to_yield.is_some() {
+				return Ok(Async::Ready(value_to_yield));
+			}
+		}
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use contracts;
-    use rustc_hex::FromHex;
-    use tokio_core::reactor::Core;
-    use web3::types::{Bytes, Log};
+	use super::*;
+	use contracts;
+	use rustc_hex::FromHex;
+	use tokio_core::reactor::Core;
+	use web3::types::{Bytes, Log};
 
-    #[test]
-    fn test_log_stream_twice_no_logs() {
-        let deposit_topic = contracts::main::events::relay_message::filter().topic0;
+	#[test]
+	fn test_log_stream_twice_no_logs() {
+		let deposit_topic = contracts::main::events::relay_message::filter().topic0;
 
-        let transport = mock_transport!(
-            "eth_blockNumber" =>
-                req => json!([]),
-                res => json!("0x1011");
-            "eth_getLogs" =>
-                req => json!([{
-                    "address": "0x0000000000000000000000000000000000000001",
-                    "fromBlock": "0x4",
-                    "toBlock": "0x1005",
-                    "topics": [deposit_topic]
-                }]),
-                res => json!([]);
-            "eth_blockNumber" =>
-                req => json!([]),
-                res => json!("0x1012");
-            "eth_getLogs" =>
-                req => json!([{
-                    "address": "0x0000000000000000000000000000000000000001",
-                    "fromBlock": "0x1006",
-                    "toBlock": "0x1006",
-                    "topics": [deposit_topic]
-                }]),
-                res => json!([]);
-        );
+		let transport = mock_transport!(
+			"eth_blockNumber" =>
+				req => json!([]),
+				res => json!("0x1011");
+			"eth_getLogs" =>
+				req => json!([{
+					"address": "0x0000000000000000000000000000000000000001",
+					"fromBlock": "0x4",
+					"toBlock": "0x1005",
+					"topics": [deposit_topic]
+				}]),
+				res => json!([]);
+			"eth_blockNumber" =>
+				req => json!([]),
+				res => json!("0x1012");
+			"eth_getLogs" =>
+				req => json!([{
+					"address": "0x0000000000000000000000000000000000000001",
+					"fromBlock": "0x1006",
+					"toBlock": "0x1006",
+					"topics": [deposit_topic]
+				}]),
+				res => json!([]);
+		);
 
-        let log_stream = LogStream::new(LogStreamOptions {
-            request_timeout: Duration::from_secs(1),
-            poll_interval: Duration::from_secs(1),
-            confirmations: 12,
-            transport: transport.clone(),
-            contract_address: "0000000000000000000000000000000000000001".parse().unwrap(),
-            after: 3,
-            filter: contracts::main::events::relay_message::filter(),
-        });
+		let log_stream = LogStream::new(LogStreamOptions {
+			request_timeout: Duration::from_secs(1),
+			poll_interval: Duration::from_secs(1),
+			confirmations: 12,
+			transport: transport.clone(),
+			contract_address: "0000000000000000000000000000000000000001".parse().unwrap(),
+			after: 3,
+			filter: contracts::main::events::relay_message::filter(),
+		});
 
-        let mut event_loop = Core::new().unwrap();
-        let log_ranges = event_loop.run(log_stream.take(2).collect()).unwrap();
+		let mut event_loop = Core::new().unwrap();
+		let log_ranges = event_loop.run(log_stream.take(2).collect()).unwrap();
 
-        assert_eq!(
-            log_ranges,
-            vec![
-                LogsInBlockRange {
-                    from: 4,
-                    to: 4101,
-                    logs: vec![],
-                },
-                LogsInBlockRange {
-                    from: 4102,
-                    to: 4102,
-                    logs: vec![],
-                },
-            ]
-        );
-        assert_eq!(transport.actual_requests(), transport.expected_requests());
-    }
+		assert_eq!(
+			log_ranges,
+			vec![
+				LogsInBlockRange {
+					from: 4,
+					to: 4101,
+					logs: vec![],
+				},
+				LogsInBlockRange {
+					from: 4102,
+					to: 4102,
+					logs: vec![],
+				},
+			]
+		);
+		assert_eq!(transport.actual_requests(), transport.expected_requests());
+	}
 
-    #[test]
-    fn test_log_stream_once_one_log() {
-        let deposit_topic = contracts::main::events::relay_message::filter().topic0;
+	#[test]
+	fn test_log_stream_once_one_log() {
+		let deposit_topic = contracts::main::events::relay_message::filter().topic0;
 
-        let transport = mock_transport!(
-            "eth_blockNumber" =>
-                req => json!([]),
-                res => json!("0x1011");
-            "eth_getLogs" =>
-                req => json!([{
-                    "address": "0x0000000000000000000000000000000000000001",
-                    "fromBlock": "0x4",
-                    "toBlock": "0x1005",
-                    "topics": [deposit_topic],
-                }]),
-                res => json!([{
-                    "address": "0x0000000000000000000000000000000000000cc1",
-                    "topics": [deposit_topic],
-                    "data": "0x000000000000000000000000aff3454fce5edbc8cca8697c15331677e6ebcccc00000000000000000000000000000000000000000000000000000000000000f0",
-                    "type": "",
-                    "transactionHash": "0x884edad9ce6fa2440d8a54cc123490eb96d2768479d49ff9c7366125a9424364"
-                }]);
-        );
+		let transport = mock_transport!(
+			"eth_blockNumber" =>
+				req => json!([]),
+				res => json!("0x1011");
+			"eth_getLogs" =>
+				req => json!([{
+					"address": "0x0000000000000000000000000000000000000001",
+					"fromBlock": "0x4",
+					"toBlock": "0x1005",
+					"topics": [deposit_topic],
+				}]),
+				res => json!([{
+					"address": "0x0000000000000000000000000000000000000cc1",
+					"topics": [deposit_topic],
+					"data": "0x000000000000000000000000aff3454fce5edbc8cca8697c15331677e6ebcccc00000000000000000000000000000000000000000000000000000000000000f0",
+					"type": "",
+					"transactionHash": "0x884edad9ce6fa2440d8a54cc123490eb96d2768479d49ff9c7366125a9424364"
+				}]);
+		);
 
-        let log_stream = LogStream::new(LogStreamOptions {
-            request_timeout: Duration::from_secs(1),
-            poll_interval: Duration::from_secs(1),
-            confirmations: 12,
-            transport: transport.clone(),
-            contract_address: "0000000000000000000000000000000000000001".parse().unwrap(),
-            after: 3,
-            filter: contracts::main::events::relay_message::filter(),
-        });
+		let log_stream = LogStream::new(LogStreamOptions {
+			request_timeout: Duration::from_secs(1),
+			poll_interval: Duration::from_secs(1),
+			confirmations: 12,
+			transport: transport.clone(),
+			contract_address: "0000000000000000000000000000000000000001".parse().unwrap(),
+			after: 3,
+			filter: contracts::main::events::relay_message::filter(),
+		});
 
-        let mut event_loop = Core::new().unwrap();
-        let log_ranges = event_loop.run(log_stream.take(1).collect()).unwrap();
+		let mut event_loop = Core::new().unwrap();
+		let log_ranges = event_loop.run(log_stream.take(1).collect()).unwrap();
 
-        assert_eq!(
-            log_ranges,
-            vec![
-                LogsInBlockRange { from: 4, to: 4101, logs: vec![
-                    Log {
-                        address: "0000000000000000000000000000000000000cc1".parse().unwrap(),
-                        topics: deposit_topic.into(),
-                        data: Bytes("000000000000000000000000aff3454fce5edbc8cca8697c15331677e6ebcccc00000000000000000000000000000000000000000000000000000000000000f0".from_hex().unwrap()),
-                        transaction_hash: Some("884edad9ce6fa2440d8a54cc123490eb96d2768479d49ff9c7366125a9424364".parse().unwrap()),
-                        block_hash: None,
-                        block_number: None,
-                        transaction_index: None,
-                        log_index: None,
-                        transaction_log_index: None,
-                        log_type: None,
-                        removed: None,
-                    }
-                ] },
-            ]);
-        assert_eq!(transport.actual_requests(), transport.expected_requests());
-    }
+		assert_eq!(
+			log_ranges,
+			vec![
+				LogsInBlockRange { from: 4, to: 4101, logs: vec![
+					Log {
+						address: "0000000000000000000000000000000000000cc1".parse().unwrap(),
+						topics: deposit_topic.into(),
+						data: Bytes("000000000000000000000000aff3454fce5edbc8cca8697c15331677e6ebcccc00000000000000000000000000000000000000000000000000000000000000f0".from_hex().unwrap()),
+						transaction_hash: Some("884edad9ce6fa2440d8a54cc123490eb96d2768479d49ff9c7366125a9424364".parse().unwrap()),
+						block_hash: None,
+						block_number: None,
+						transaction_index: None,
+						log_index: None,
+						transaction_log_index: None,
+						log_type: None,
+						removed: None,
+					}
+				] },
+			]);
+		assert_eq!(transport.actual_requests(), transport.expected_requests());
+	}
 }

--- a/bridge/src/macros.rs
+++ b/bridge/src/macros.rs
@@ -15,28 +15,28 @@
 // along with Parity-Bridge.  If not, see <http://www.gnu.org/licenses/>.
 /// like `try_ready!` but for streams
 macro_rules! try_stream {
-    ($e:expr) => {
-        match $e {
-            Err(err) => return Err(From::from(err)),
-            Ok($crate::futures::Async::NotReady) => return Ok($crate::futures::Async::NotReady),
-            Ok($crate::futures::Async::Ready(None)) => {
-                return Ok($crate::futures::Async::Ready(None))
-            }
-            Ok($crate::futures::Async::Ready(Some(value))) => value,
-        }
-    };
+	($e:expr) => {
+		match $e {
+			Err(err) => return Err(From::from(err)),
+			Ok($crate::futures::Async::NotReady) => return Ok($crate::futures::Async::NotReady),
+			Ok($crate::futures::Async::Ready(None)) => {
+				return Ok($crate::futures::Async::Ready(None))
+				}
+			Ok($crate::futures::Async::Ready(Some(value))) => value,
+			}
+	};
 }
 
 /// like `try_stream` but returns `None` if `NotReady`
 macro_rules! try_maybe_stream {
-    ($e:expr) => {
-        match $e {
-            Err(err) => return Err(From::from(err)),
-            Ok($crate::futures::Async::NotReady) => None,
-            Ok($crate::futures::Async::Ready(None)) => {
-                return Ok($crate::futures::Async::Ready(None))
-            }
-            Ok($crate::futures::Async::Ready(Some(value))) => Some(value),
-        }
-    };
+	($e:expr) => {
+		match $e {
+			Err(err) => return Err(From::from(err)),
+			Ok($crate::futures::Async::NotReady) => None,
+			Ok($crate::futures::Async::Ready(None)) => {
+				return Ok($crate::futures::Async::Ready(None))
+				}
+			Ok($crate::futures::Async::Ready(Some(value))) => Some(value),
+			}
+	};
 }

--- a/bridge/src/main_contract.rs
+++ b/bridge/src/main_contract.rs
@@ -28,96 +28,96 @@ use web3::Transport;
 /// highlevel wrapper around the auto generated ethabi contract `bridge_contracts::main`
 #[derive(Clone)]
 pub struct MainContract<T> {
-    pub transport: T,
-    pub contract_address: Address,
-    pub authority_address: Address,
-    pub submit_collected_signatures_gas: U256,
-    pub request_timeout: Duration,
-    pub logs_poll_interval: Duration,
-    pub required_log_confirmations: u32,
+	pub transport: T,
+	pub contract_address: Address,
+	pub authority_address: Address,
+	pub submit_collected_signatures_gas: U256,
+	pub request_timeout: Duration,
+	pub logs_poll_interval: Duration,
+	pub required_log_confirmations: u32,
 }
 
 impl<T: Transport> MainContract<T> {
-    pub fn new(transport: T, config: &Config, state: &State) -> Self {
-        Self {
-            transport,
-            contract_address: state.main_contract_address,
-            authority_address: config.address,
-            submit_collected_signatures_gas: config.estimated_gas_cost_of_withdraw,
-            request_timeout: config.main.request_timeout,
-            logs_poll_interval: config.main.poll_interval,
-            required_log_confirmations: config.main.required_confirmations,
-        }
-    }
+	pub fn new(transport: T, config: &Config, state: &State) -> Self {
+		Self {
+			transport,
+			contract_address: state.main_contract_address,
+			authority_address: config.address,
+			submit_collected_signatures_gas: config.estimated_gas_cost_of_withdraw,
+			request_timeout: config.main.request_timeout,
+			logs_poll_interval: config.main.poll_interval,
+			required_log_confirmations: config.main.required_confirmations,
+		}
+	}
 
-    pub fn call<F: FunctionOutputDecoder>(
-        &self,
-        payload: Vec<u8>,
-        output_decoder: F,
-    ) -> AsyncCall<T, F> {
-        AsyncCall::new(
-            &self.transport,
-            self.contract_address,
-            self.request_timeout,
-            payload,
-            output_decoder,
-        )
-    }
+	pub fn call<F: FunctionOutputDecoder>(
+		&self,
+		payload: Vec<u8>,
+		output_decoder: F,
+	) -> AsyncCall<T, F> {
+		AsyncCall::new(
+			&self.transport,
+			self.contract_address,
+			self.request_timeout,
+			payload,
+			output_decoder,
+		)
+	}
 
-    pub fn is_main_contract(
-        &self,
-    ) -> AsyncCall<T, contracts::main::functions::is_main_bridge_contract::Decoder> {
-        let (payload, decoder) = contracts::main::functions::is_main_bridge_contract::call();
-        self.call(payload, decoder)
-    }
+	pub fn is_main_contract(
+		&self,
+	) -> AsyncCall<T, contracts::main::functions::is_main_bridge_contract::Decoder> {
+		let (payload, decoder) = contracts::main::functions::is_main_bridge_contract::call();
+		self.call(payload, decoder)
+	}
 
-    /// relay a tx from side to main by submitting message and collected signatures
-    pub fn relay_side_to_main(
-        &self,
-        message: &MessageToMain,
-        signatures: &Vec<Signature>,
-        data: Vec<u8>,
-    ) -> AsyncTransaction<T> {
-        let payload = contracts::main::functions::accept_message::encode_input(
-            signatures.iter().map(|x| x.v),
-            signatures.iter().map(|x| x.r),
-            signatures.iter().map(|x| x.s),
-            message.side_tx_hash,
-            data,
-            message.sender,
-            message.recipient,
-        );
+	/// relay a tx from side to main by submitting message and collected signatures
+	pub fn relay_side_to_main(
+		&self,
+		message: &MessageToMain,
+		signatures: &Vec<Signature>,
+		data: Vec<u8>,
+	) -> AsyncTransaction<T> {
+		let payload = contracts::main::functions::accept_message::encode_input(
+			signatures.iter().map(|x| x.v),
+			signatures.iter().map(|x| x.r),
+			signatures.iter().map(|x| x.s),
+			message.side_tx_hash,
+			data,
+			message.sender,
+			message.recipient,
+		);
 
-        AsyncTransaction::new(
-            &self.transport,
-            self.contract_address,
-            self.authority_address,
-            self.submit_collected_signatures_gas,
-            // TODO:
-            //message.main_gas_price,
-            1000.into(),
-            self.request_timeout,
-            payload,
-        )
-    }
+		AsyncTransaction::new(
+			&self.transport,
+			self.contract_address,
+			self.authority_address,
+			self.submit_collected_signatures_gas,
+			// TODO:
+			//message.main_gas_price,
+			1000.into(),
+			self.request_timeout,
+			payload,
+		)
+	}
 
-    pub fn main_to_side_log_stream(&self, after: u64) -> LogStream<T> {
-        LogStream::new(LogStreamOptions {
-            filter: contracts::main::events::relay_message::filter(),
-            request_timeout: self.request_timeout,
-            poll_interval: self.logs_poll_interval,
-            confirmations: self.required_log_confirmations,
-            transport: self.transport.clone(),
-            contract_address: self.contract_address,
-            after,
-        })
-    }
+	pub fn main_to_side_log_stream(&self, after: u64) -> LogStream<T> {
+		LogStream::new(LogStreamOptions {
+			filter: contracts::main::events::relay_message::filter(),
+			request_timeout: self.request_timeout,
+			poll_interval: self.logs_poll_interval,
+			confirmations: self.required_log_confirmations,
+			transport: self.transport.clone(),
+			contract_address: self.contract_address,
+			after,
+		})
+	}
 
-    pub fn relayed_message_by_id(
-        &self,
-        id: H256,
-    ) -> AsyncCall<T, contracts::main::functions::relayed_messages::Decoder> {
-        let (payload, decoder) = contracts::main::functions::relayed_messages::call(id);
-        self.call(payload, decoder)
-    }
+	pub fn relayed_message_by_id(
+		&self,
+		id: H256,
+	) -> AsyncCall<T, contracts::main::functions::relayed_messages::Decoder> {
+		let (payload, decoder) = contracts::main::functions::relayed_messages::call(id);
+		self.call(payload, decoder)
+	}
 }

--- a/bridge/src/message_to_main.rs
+++ b/bridge/src/message_to_main.rs
@@ -28,129 +28,129 @@ use web3::types::Log;
 /// one node submits this message and signatures in `SideToMainSignatures`.
 #[derive(PartialEq, Debug, Clone)]
 pub struct MessageToMain {
-    pub side_tx_hash: H256,
-    pub message_id: H256,
-    pub sender: Address,
-    pub recipient: Address,
+	pub side_tx_hash: H256,
+	pub message_id: H256,
+	pub sender: Address,
+	pub recipient: Address,
 }
 
 /// length of a `MessageToMain.to_bytes()` in bytes
 pub const MESSAGE_LENGTH: usize = 32 + 32 + 20 + 20;
 
 impl MessageToMain {
-    /// parses message from a byte slice
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        if bytes.len() != MESSAGE_LENGTH {
-            bail!("`bytes`.len() must be {}", MESSAGE_LENGTH);
-        }
+	/// parses message from a byte slice
+	pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+		if bytes.len() != MESSAGE_LENGTH {
+			bail!("`bytes`.len() must be {}", MESSAGE_LENGTH);
+		}
 
-        Ok(Self {
-            side_tx_hash: H256::from_slice(&bytes[0..32]),
-            message_id: H256::from_slice(&bytes[32..64]),
-            sender: Address::from_slice(&bytes[64..84]),
-            recipient: Address::from_slice(&bytes[84..104]),
-        })
-    }
+		Ok(Self {
+			side_tx_hash: H256::from_slice(&bytes[0..32]),
+			message_id: H256::from_slice(&bytes[32..64]),
+			sender: Address::from_slice(&bytes[64..84]),
+			recipient: Address::from_slice(&bytes[84..104]),
+		})
+	}
 
-    pub fn keccak256(&self) -> H256 {
-        H256::from_slice(&tiny_keccak::keccak256(&self.to_bytes()))
-    }
+	pub fn keccak256(&self) -> H256 {
+		H256::from_slice(&tiny_keccak::keccak256(&self.to_bytes()))
+	}
 
-    /// construct a message from a `Withdraw` event that was logged on `side`
-    pub fn from_log(raw_log: &Log) -> Result<Self, Error> {
-        let hash = raw_log
-            .transaction_hash
-            .ok_or_else(|| "`log` must be mined and contain `transaction_hash`")?;
-        let log = helpers::parse_log(contracts::side::events::relay_message::parse_log, raw_log)?;
-        Ok(Self {
-            side_tx_hash: hash,
-            message_id: log.message_id,
-            sender: log.sender,
-            recipient: log.recipient,
-        })
-    }
+	/// construct a message from a `Withdraw` event that was logged on `side`
+	pub fn from_log(raw_log: &Log) -> Result<Self, Error> {
+		let hash = raw_log
+			.transaction_hash
+			.ok_or_else(|| "`log` must be mined and contain `transaction_hash`")?;
+		let log = helpers::parse_log(contracts::side::events::relay_message::parse_log, raw_log)?;
+		Ok(Self {
+			side_tx_hash: hash,
+			message_id: log.message_id,
+			sender: log.sender,
+			recipient: log.recipient,
+		})
+	}
 
-    /// serializes message to a byte vector.
-    /// mainly used to construct the message byte vector that is then signed
-    /// and passed to `SideBridge.submitSignature`
-    pub fn to_bytes(&self) -> Vec<u8> {
-        let mut result = vec![0u8; MESSAGE_LENGTH];
-        result[0..32].copy_from_slice(&self.side_tx_hash.0[..]);
-        result[32..64].copy_from_slice(&self.message_id.0[..]);
-        result[64..84].copy_from_slice(&self.sender.0[..]);
-        result[84..104].copy_from_slice(&self.recipient.0[..]);
-        return result;
-    }
+	/// serializes message to a byte vector.
+	/// mainly used to construct the message byte vector that is then signed
+	/// and passed to `SideBridge.submitSignature`
+	pub fn to_bytes(&self) -> Vec<u8> {
+		let mut result = vec![0u8; MESSAGE_LENGTH];
+		result[0..32].copy_from_slice(&self.side_tx_hash.0[..]);
+		result[32..64].copy_from_slice(&self.message_id.0[..]);
+		result[64..84].copy_from_slice(&self.sender.0[..]);
+		result[84..104].copy_from_slice(&self.recipient.0[..]);
+		return result;
+	}
 
-    /// serializes message to an ethabi payload
-    pub fn to_payload(&self) -> Vec<u8> {
-        ethabi::encode(&[ethabi::Token::Bytes(self.to_bytes())])
-    }
+	/// serializes message to an ethabi payload
+	pub fn to_payload(&self) -> Vec<u8> {
+		ethabi::encode(&[ethabi::Token::Bytes(self.to_bytes())])
+	}
 }
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use quickcheck::TestResult;
-    use rustc_hex::FromHex;
+	use super::*;
+	use quickcheck::TestResult;
+	use rustc_hex::FromHex;
 
-    #[test]
-    fn test_message_to_main_to_bytes() {
-        let side_tx_hash: H256 = "75ebc3036b5a5a758be9a8c0e6f6ed8d46c640dda39845de99d9570ba76798e2"
-            .parse()
-            .unwrap();
-        let message_id: H256 = "75ebc3036b5a5a758be9a8c0e6f6ed8d46c640dda39845de99d9570ba76798ff"
-            .parse()
-            .unwrap();
-        let sender: Address = "eac4a655451e159313c3641e29824e77d6fcb0aa".parse().unwrap();
-        let recipient: Address = "eac4a655451e159313c3641e29824e77d6fcb0bb".parse().unwrap();
+	#[test]
+	fn test_message_to_main_to_bytes() {
+		let side_tx_hash: H256 = "75ebc3036b5a5a758be9a8c0e6f6ed8d46c640dda39845de99d9570ba76798e2"
+			.parse()
+			.unwrap();
+		let message_id: H256 = "75ebc3036b5a5a758be9a8c0e6f6ed8d46c640dda39845de99d9570ba76798ff"
+			.parse()
+			.unwrap();
+		let sender: Address = "eac4a655451e159313c3641e29824e77d6fcb0aa".parse().unwrap();
+		let recipient: Address = "eac4a655451e159313c3641e29824e77d6fcb0bb".parse().unwrap();
 
-        let message = MessageToMain {
-            side_tx_hash,
-            message_id,
-            sender,
-            recipient,
-        };
+		let message = MessageToMain {
+			side_tx_hash,
+			message_id,
+			sender,
+			recipient,
+		};
 
-        assert_eq!(message.to_bytes(), "75ebc3036b5a5a758be9a8c0e6f6ed8d46c640dda39845de99d9570ba76798e275ebc3036b5a5a758be9a8c0e6f6ed8d46c640dda39845de99d9570ba76798ffeac4a655451e159313c3641e29824e77d6fcb0aaeac4a655451e159313c3641e29824e77d6fcb0bb".from_hex::<Vec<u8>>().unwrap())
-    }
+		assert_eq!(message.to_bytes(), "75ebc3036b5a5a758be9a8c0e6f6ed8d46c640dda39845de99d9570ba76798e275ebc3036b5a5a758be9a8c0e6f6ed8d46c640dda39845de99d9570ba76798ffeac4a655451e159313c3641e29824e77d6fcb0aaeac4a655451e159313c3641e29824e77d6fcb0bb".from_hex::<Vec<u8>>().unwrap())
+	}
 
-    quickcheck! {
-        fn quickcheck_message_to_main_roundtrips_to_bytes(
-            side_tx_hash_raw: Vec<u8>,
-            message_id_raw: Vec<u8>,
-            sender_raw: Vec<u8>,
-            recipient_raw: Vec<u8>
-        ) -> TestResult {
-            if side_tx_hash_raw.len() != 32 ||
-                message_id_raw.len() != 32 ||
-                sender_raw.len() != 20 ||
-                recipient_raw.len() != 20 {
-                return TestResult::discard();
-            }
+	quickcheck! {
+		fn quickcheck_message_to_main_roundtrips_to_bytes(
+			side_tx_hash_raw: Vec<u8>,
+			message_id_raw: Vec<u8>,
+			sender_raw: Vec<u8>,
+			recipient_raw: Vec<u8>
+		) -> TestResult {
+			if side_tx_hash_raw.len() != 32 ||
+				message_id_raw.len() != 32 ||
+				sender_raw.len() != 20 ||
+				recipient_raw.len() != 20 {
+				return TestResult::discard();
+			}
 
-            let side_tx_hash = H256::from_slice(side_tx_hash_raw.as_slice());
-            let message_id = H256::from_slice(message_id_raw.as_slice());
-            let sender = Address::from_slice(sender_raw.as_slice());
-            let recipient = Address::from_slice(recipient_raw.as_slice());
+			let side_tx_hash = H256::from_slice(side_tx_hash_raw.as_slice());
+			let message_id = H256::from_slice(message_id_raw.as_slice());
+			let sender = Address::from_slice(sender_raw.as_slice());
+			let recipient = Address::from_slice(recipient_raw.as_slice());
 
-            let message = MessageToMain {
-                side_tx_hash,
-                message_id,
-                sender,
-                recipient,
-            };
+			let message = MessageToMain {
+				side_tx_hash,
+				message_id,
+				sender,
+				recipient,
+			};
 
-            let bytes = message.to_bytes();
-            assert_eq!(message, MessageToMain::from_bytes(bytes.as_slice()).unwrap());
+			let bytes = message.to_bytes();
+			assert_eq!(message, MessageToMain::from_bytes(bytes.as_slice()).unwrap());
 
-            let payload = message.to_payload();
-            let mut tokens = ethabi::decode(&[ethabi::ParamType::Bytes], payload.as_slice())
-                .unwrap();
-            let decoded = tokens.pop().unwrap().to_bytes().unwrap();
-            assert_eq!(message, MessageToMain::from_bytes(decoded.as_slice()).unwrap());
+			let payload = message.to_payload();
+			let mut tokens = ethabi::decode(&[ethabi::ParamType::Bytes], payload.as_slice())
+				.unwrap();
+			let decoded = tokens.pop().unwrap().to_bytes().unwrap();
+			assert_eq!(message, MessageToMain::from_bytes(decoded.as_slice()).unwrap());
 
-            TestResult::passed()
-        }
-    }
+			TestResult::passed()
+		}
+	}
 }

--- a/bridge/src/relay_stream.rs
+++ b/bridge/src/relay_stream.rs
@@ -26,9 +26,9 @@ use OrderedStream;
 /// something that can create relay futures from logs.
 /// to be called by `RelayStream` for every log.
 pub trait LogToFuture {
-    type Future: Future<Error = error::Error>;
+	type Future: Future<Error = error::Error>;
 
-    fn log_to_future(&self, log: &Log) -> Self::Future;
+	fn log_to_future(&self, log: &Log) -> Self::Future;
 }
 
 /// a tokio `Stream` that when polled fetches all new logs from `stream_of_logs`
@@ -38,68 +38,68 @@ pub trait LogToFuture {
 /// those block numbers can then be persisted since they'll never need to be
 /// checked again.
 pub struct RelayStream<S: Stream<Item = LogsInBlockRange, Error = error::Error>, F: LogToFuture> {
-    stream_of_logs: S,
-    log_to_future: F,
-    /// reorders relay futures so they are yielded in block order
-    /// rather than the order they complete.
-    /// this is required because relay futures are not guaranteed to
-    /// complete in block order.
-    ordered_stream: OrderedStream<u64, F::Future>,
+	stream_of_logs: S,
+	log_to_future: F,
+	/// reorders relay futures so they are yielded in block order
+	/// rather than the order they complete.
+	/// this is required because relay futures are not guaranteed to
+	/// complete in block order.
+	ordered_stream: OrderedStream<u64, F::Future>,
 }
 
 impl<S: Stream<Item = LogsInBlockRange, Error = error::Error>, F: LogToFuture> RelayStream<S, F> {
-    pub fn new(stream_of_logs: S, log_to_future: F) -> Self {
-        Self {
-            stream_of_logs,
-            log_to_future,
-            ordered_stream: OrderedStream::new(),
-        }
-    }
+	pub fn new(stream_of_logs: S, log_to_future: F) -> Self {
+		Self {
+			stream_of_logs,
+			log_to_future,
+			ordered_stream: OrderedStream::new(),
+		}
+	}
 }
 
 impl<S: Stream<Item = LogsInBlockRange, Error = error::Error>, F: LogToFuture> Stream
-    for RelayStream<S, F>
+	for RelayStream<S, F>
 {
-    type Item = u64;
-    type Error = error::Error;
+	type Item = u64;
+	type Error = error::Error;
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        // on each poll we loop until there are neither new logs
-        // nor newly completed relays
-        loop {
-            let maybe_logs_in_block_range = try_maybe_stream!(self
-                .stream_of_logs
-                .poll()
-                .chain_err(|| "RelayStream: fetching logs failed"));
+	fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+		// on each poll we loop until there are neither new logs
+		// nor newly completed relays
+		loop {
+			let maybe_logs_in_block_range = try_maybe_stream!(self
+				.stream_of_logs
+				.poll()
+				.chain_err(|| "RelayStream: fetching logs failed"));
 
-            if let Some(ref logs_in_block_range) = maybe_logs_in_block_range {
-                // if there are new logs, create futures from them
-                // which are responsible for the relay and add them to the
-                // ordered stream
-                for log in &logs_in_block_range.logs {
-                    let relay_future = self.log_to_future.log_to_future(log);
-                    self.ordered_stream
-                        .insert(logs_in_block_range.to, relay_future);
-                }
-            }
+			if let Some(ref logs_in_block_range) = maybe_logs_in_block_range {
+				// if there are new logs, create futures from them
+				// which are responsible for the relay and add them to the
+				// ordered stream
+				for log in &logs_in_block_range.logs {
+					let relay_future = self.log_to_future.log_to_future(log);
+					self.ordered_stream
+						.insert(logs_in_block_range.to, relay_future);
+				}
+			}
 
-            let maybe_fully_relayed_until_block = try_maybe_stream!(self
-                .ordered_stream
-                .poll()
-                .chain_err(|| "RelayStream: relaying logs failed"));
+			let maybe_fully_relayed_until_block = try_maybe_stream!(self
+				.ordered_stream
+				.poll()
+				.chain_err(|| "RelayStream: relaying logs failed"));
 
-            if let Some((fully_relayed_until_block, _)) = maybe_fully_relayed_until_block {
-                // all relay futures for this block or before have completed
-                // we can yield the block number which can be safely
-                // persisted since it doesn't need to get checked again
-                return Ok(Async::Ready(Some(fully_relayed_until_block)));
-            }
+			if let Some((fully_relayed_until_block, _)) = maybe_fully_relayed_until_block {
+				// all relay futures for this block or before have completed
+				// we can yield the block number which can be safely
+				// persisted since it doesn't need to get checked again
+				return Ok(Async::Ready(Some(fully_relayed_until_block)));
+			}
 
-            if maybe_logs_in_block_range.is_none() && maybe_fully_relayed_until_block.is_none() {
-                // there are neither new logs nor is there a new block number
-                // until which all relays have completed
-                return Ok(Async::NotReady);
-            }
-        }
-    }
+			if maybe_logs_in_block_range.is_none() && maybe_fully_relayed_until_block.is_none() {
+				// there are neither new logs nor is there a new block number
+				// until which all relays have completed
+				return Ok(Async::NotReady);
+			}
+		}
+	}
 }

--- a/bridge/src/send_tx_with_receipt.rs
+++ b/bridge/src/send_tx_with_receipt.rs
@@ -25,366 +25,366 @@ use web3::types::{TransactionReceipt, TransactionRequest, U64};
 use web3::{self, Transport};
 
 mod inner {
-    use block_number_stream::{BlockNumberStream, BlockNumberStreamOptions};
-    use error::{self, ResultExt};
-    use futures::future::FromErr;
-    use futures::{Async, Future, Poll, Stream};
-    use std::time::Duration;
-    use tokio_timer::{Timeout, Timer};
-    use web3::api::Namespace;
-    use web3::helpers::CallFuture;
-    use web3::types::{TransactionReceipt, TransactionRequest, H256};
-    use web3::{self, Transport};
+	use block_number_stream::{BlockNumberStream, BlockNumberStreamOptions};
+	use error::{self, ResultExt};
+	use futures::future::FromErr;
+	use futures::{Async, Future, Poll, Stream};
+	use std::time::Duration;
+	use tokio_timer::{Timeout, Timer};
+	use web3::api::Namespace;
+	use web3::helpers::CallFuture;
+	use web3::types::{TransactionReceipt, TransactionRequest, H256};
+	use web3::{self, Transport};
 
-    enum State<T: Transport> {
-        AwaitSendTransaction(Timeout<FromErr<CallFuture<H256, T::Out>, error::Error>>),
-        AwaitBlockNumber(H256),
-        AwaitTransactionReceipt {
-            future: Timeout<FromErr<CallFuture<Option<TransactionReceipt>, T::Out>, error::Error>>,
-            transaction_hash: H256,
-            last_block: u64,
-        },
-    }
+	enum State<T: Transport> {
+		AwaitSendTransaction(Timeout<FromErr<CallFuture<H256, T::Out>, error::Error>>),
+		AwaitBlockNumber(H256),
+		AwaitTransactionReceipt {
+			future: Timeout<FromErr<CallFuture<Option<TransactionReceipt>, T::Out>, error::Error>>,
+			transaction_hash: H256,
+			last_block: u64,
+		},
+	}
 
-    pub struct SendTransactionWithReceiptOptions<T: Transport> {
-        pub transport: T,
-        pub request_timeout: Duration,
-        pub poll_interval: Duration,
-        pub confirmations: u32,
-        pub transaction: TransactionRequest,
-        pub after: u64,
-    }
+	pub struct SendTransactionWithReceiptOptions<T: Transport> {
+		pub transport: T,
+		pub request_timeout: Duration,
+		pub poll_interval: Duration,
+		pub confirmations: u32,
+		pub transaction: TransactionRequest,
+		pub after: u64,
+	}
 
-    pub struct SendTransactionWithReceipt<T: Transport> {
-        transport: T,
-        state: State<T>,
-        block_number_stream: BlockNumberStream<T>,
-        request_timeout: Duration,
-        timer: Timer,
-    }
+	pub struct SendTransactionWithReceipt<T: Transport> {
+		transport: T,
+		state: State<T>,
+		block_number_stream: BlockNumberStream<T>,
+		request_timeout: Duration,
+		timer: Timer,
+	}
 
-    impl<T: Transport> SendTransactionWithReceipt<T> {
-        pub fn new(options: SendTransactionWithReceiptOptions<T>) -> Self {
-            let timer = Timer::default();
+	impl<T: Transport> SendTransactionWithReceipt<T> {
+		pub fn new(options: SendTransactionWithReceiptOptions<T>) -> Self {
+			let timer = Timer::default();
 
-            let block_number_stream_options = BlockNumberStreamOptions {
-                request_timeout: options.request_timeout,
-                poll_interval: options.poll_interval,
-                confirmations: options.confirmations,
-                transport: options.transport.clone(),
-                after: options.after,
-            };
-            let block_number_stream = BlockNumberStream::new(block_number_stream_options);
-            let future =
-                web3::api::Eth::new(&options.transport).send_transaction(options.transaction);
-            let future = timer.timeout(future.from_err(), options.request_timeout);
+			let block_number_stream_options = BlockNumberStreamOptions {
+				request_timeout: options.request_timeout,
+				poll_interval: options.poll_interval,
+				confirmations: options.confirmations,
+				transport: options.transport.clone(),
+				after: options.after,
+			};
+			let block_number_stream = BlockNumberStream::new(block_number_stream_options);
+			let future =
+				web3::api::Eth::new(&options.transport).send_transaction(options.transaction);
+			let future = timer.timeout(future.from_err(), options.request_timeout);
 
-            SendTransactionWithReceipt {
-                transport: options.transport,
-                state: State::AwaitSendTransaction(future),
-                block_number_stream,
-                request_timeout: options.request_timeout,
-                timer,
-            }
-        }
-    }
+			SendTransactionWithReceipt {
+				transport: options.transport,
+				state: State::AwaitSendTransaction(future),
+				block_number_stream,
+				request_timeout: options.request_timeout,
+				timer,
+			}
+		}
+	}
 
-    impl<T: Transport> Future for SendTransactionWithReceipt<T> {
-        type Item = TransactionReceipt;
-        type Error = error::Error;
+	impl<T: Transport> Future for SendTransactionWithReceipt<T> {
+		type Item = TransactionReceipt;
+		type Error = error::Error;
 
-        fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-            loop {
-                let next_state = match self.state {
-                    State::AwaitSendTransaction(ref mut future) => {
-                        let hash = try_ready!(future.poll().chain_err(|| {
-                            "SendTransactionWithReceipt: sending transaction failed"
-                        }));
-                        info!("SendTransactionWithReceipt: sent transaction {}", hash);
-                        State::AwaitBlockNumber(hash)
-                    }
-                    State::AwaitBlockNumber(transaction_hash) => {
-                        let last_block = match try_ready!(
-                            self.block_number_stream
-                                .poll()
-                                .chain_err(|| "SendTransactionWithReceipt: fetching of last confirmed block failed")
-                            ) {
-                            Some(last_block) => last_block,
-                            None => bail!("SendTransactionWithReceipt: fetching of last confirmed block failed"),
-                        };
+		fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+			loop {
+				let next_state = match self.state {
+					State::AwaitSendTransaction(ref mut future) => {
+						let hash = try_ready!(future.poll().chain_err(|| {
+							"SendTransactionWithReceipt: sending transaction failed"
+						}));
+						info!("SendTransactionWithReceipt: sent transaction {}", hash);
+						State::AwaitBlockNumber(hash)
+					}
+					State::AwaitBlockNumber(transaction_hash) => {
+						let last_block = match try_ready!(
+							self.block_number_stream
+								.poll()
+								.chain_err(|| "SendTransactionWithReceipt: fetching of last confirmed block failed")
+							) {
+							Some(last_block) => last_block,
+							None => bail!("SendTransactionWithReceipt: fetching of last confirmed block failed"),
+						};
 
-                        info!(
-                            "SendTransactionWithReceipt: fetched confirmed block number {}",
-                            last_block
-                        );
-                        let future = web3::api::Eth::new(&self.transport)
-                            .transaction_receipt(transaction_hash);
-                        State::AwaitTransactionReceipt {
-                            future: self.timer.timeout(future.from_err(), self.request_timeout),
-                            transaction_hash,
-                            last_block,
-                        }
-                    }
-                    State::AwaitTransactionReceipt {
-                        ref mut future,
-                        transaction_hash,
-                        last_block,
-                    } => {
-                        let maybe_receipt = try_ready!(future.poll().chain_err(|| {
-                            "SendTransactionWithReceipt: getting transaction receipt failed"
-                        }));
+						info!(
+							"SendTransactionWithReceipt: fetched confirmed block number {}",
+							last_block
+						);
+						let future = web3::api::Eth::new(&self.transport)
+							.transaction_receipt(transaction_hash);
+						State::AwaitTransactionReceipt {
+							future: self.timer.timeout(future.from_err(), self.request_timeout),
+							transaction_hash,
+							last_block,
+						}
+					}
+					State::AwaitTransactionReceipt {
+						ref mut future,
+						transaction_hash,
+						last_block,
+					} => {
+						let maybe_receipt = try_ready!(future.poll().chain_err(|| {
+							"SendTransactionWithReceipt: getting transaction receipt failed"
+						}));
 
-                        match maybe_receipt {
-                            // transaction hasn't been mined yet
-                            None => State::AwaitBlockNumber(transaction_hash),
-                            Some(receipt) => {
-                                info!(
-                                    "SendTransactionWithReceipt: got transaction receipt: {}",
-                                    transaction_hash
-                                );
-                                match receipt.block_number {
-                                    // receipt comes from pending block
-                                    None => State::AwaitBlockNumber(transaction_hash),
-                                    Some(receipt_block_number) => {
-                                        if last_block < receipt_block_number.as_u64() {
-                                            // transaction does not have enough confirmations
-                                            State::AwaitBlockNumber(transaction_hash)
-                                        } else {
-                                            return Ok(Async::Ready(receipt));
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                };
+						match maybe_receipt {
+							// transaction hasn't been mined yet
+							None => State::AwaitBlockNumber(transaction_hash),
+							Some(receipt) => {
+								info!(
+									"SendTransactionWithReceipt: got transaction receipt: {}",
+									transaction_hash
+								);
+								match receipt.block_number {
+									// receipt comes from pending block
+									None => State::AwaitBlockNumber(transaction_hash),
+									Some(receipt_block_number) => {
+										if last_block < receipt_block_number.as_u64() {
+											// transaction does not have enough confirmations
+											State::AwaitBlockNumber(transaction_hash)
+										} else {
+											return Ok(Async::Ready(receipt));
+										}
+									}
+								}
+							}
+						}
+					}
+				};
 
-                self.state = next_state;
-            }
-        }
-    }
+				self.state = next_state;
+			}
+		}
+	}
 }
 
 enum State<T: Transport> {
-    AwaitBlockNumber {
-        future: Timeout<FromErr<CallFuture<U64, T::Out>, error::Error>>,
-        transaction: Option<TransactionRequest>,
-    },
-    AwaitReceipt(inner::SendTransactionWithReceipt<T>),
+	AwaitBlockNumber {
+		future: Timeout<FromErr<CallFuture<U64, T::Out>, error::Error>>,
+		transaction: Option<TransactionRequest>,
+	},
+	AwaitReceipt(inner::SendTransactionWithReceipt<T>),
 }
 
 pub struct SendTransactionWithReceiptOptions<T> {
-    pub transport: T,
-    pub request_timeout: Duration,
-    pub poll_interval: Duration,
-    pub confirmations: u32,
-    pub transaction: TransactionRequest,
+	pub transport: T,
+	pub request_timeout: Duration,
+	pub poll_interval: Duration,
+	pub confirmations: u32,
+	pub transaction: TransactionRequest,
 }
 
 pub struct SendTransactionWithReceipt<T: Transport> {
-    request_timeout: Duration,
-    poll_interval: Duration,
-    transport: T,
-    state: State<T>,
-    confirmations: u32,
+	request_timeout: Duration,
+	poll_interval: Duration,
+	transport: T,
+	state: State<T>,
+	confirmations: u32,
 }
 
 impl<T: Transport> SendTransactionWithReceipt<T> {
-    pub fn new(options: SendTransactionWithReceiptOptions<T>) -> Self {
-        let timer = Timer::default();
+	pub fn new(options: SendTransactionWithReceiptOptions<T>) -> Self {
+		let timer = Timer::default();
 
-        let future = web3::api::Eth::new(&options.transport).block_number();
+		let future = web3::api::Eth::new(&options.transport).block_number();
 
-        let state = State::AwaitBlockNumber {
-            future: timer.timeout(future.from_err(), options.request_timeout),
-            transaction: Some(options.transaction),
-        };
+		let state = State::AwaitBlockNumber {
+			future: timer.timeout(future.from_err(), options.request_timeout),
+			transaction: Some(options.transaction),
+		};
 
-        SendTransactionWithReceipt {
-            request_timeout: options.request_timeout,
-            poll_interval: options.poll_interval,
-            transport: options.transport,
-            state,
-            confirmations: options.confirmations,
-        }
-    }
+		SendTransactionWithReceipt {
+			request_timeout: options.request_timeout,
+			poll_interval: options.poll_interval,
+			transport: options.transport,
+			state,
+			confirmations: options.confirmations,
+		}
+	}
 }
 
 impl<T: Transport> Future for SendTransactionWithReceipt<T> {
-    type Item = TransactionReceipt;
-    type Error = error::Error;
+	type Item = TransactionReceipt;
+	type Error = error::Error;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        loop {
-            let next_state = match self.state {
-                State::AwaitBlockNumber {
-                    ref mut future,
-                    ref mut transaction,
-                } => {
-                    let block_number = try_ready!(future.poll().chain_err(|| {
-                        "SendTransactionWithReceipt: fetching last block number failed"
-                    }));
-                    info!(
-                        "SendTransactionWithReceipt: got last block number {}",
-                        block_number
-                    );
-                    let transaction = transaction.take().expect(
-                        "SendTransactionWithReceipt is always created with
-                             State::AwaitBlockNumber with transaction set to Some; qed",
-                    );
+	fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+		loop {
+			let next_state = match self.state {
+				State::AwaitBlockNumber {
+					ref mut future,
+					ref mut transaction,
+				} => {
+					let block_number = try_ready!(future.poll().chain_err(|| {
+						"SendTransactionWithReceipt: fetching last block number failed"
+					}));
+					info!(
+						"SendTransactionWithReceipt: got last block number {}",
+						block_number
+					);
+					let transaction = transaction.take().expect(
+						"SendTransactionWithReceipt is always created with
+							 State::AwaitBlockNumber with transaction set to Some; qed",
+					);
 
-                    let inner_options = inner::SendTransactionWithReceiptOptions {
-                        transport: self.transport.clone(),
-                        request_timeout: self.request_timeout,
-                        poll_interval: self.poll_interval,
-                        confirmations: self.confirmations,
-                        transaction,
-                        after: block_number.as_u64(),
-                    };
+					let inner_options = inner::SendTransactionWithReceiptOptions {
+						transport: self.transport.clone(),
+						request_timeout: self.request_timeout,
+						poll_interval: self.poll_interval,
+						confirmations: self.confirmations,
+						transaction,
+						after: block_number.as_u64(),
+					};
 
-                    let future = inner::SendTransactionWithReceipt::new(inner_options);
-                    State::AwaitReceipt(future)
-                }
-                State::AwaitReceipt(ref mut future) => return future.poll(),
-            };
+					let future = inner::SendTransactionWithReceipt::new(inner_options);
+					State::AwaitReceipt(future)
+				}
+				State::AwaitReceipt(ref mut future) => return future.poll(),
+			};
 
-            self.state = next_state;
-        }
-    }
+			self.state = next_state;
+		}
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use tokio_core::reactor::Core;
+	use super::*;
+	use tokio_core::reactor::Core;
 
-    #[test]
-    fn test_send_tx_with_receipt() {
-        let transport = mock_transport!(
-            "eth_blockNumber" =>
-                req => json!([]),
-                res => json!("0x1010");
-            "eth_sendTransaction" =>
-                req => json!([{
-                    "data": "0x60",
-                    "from": "0x006b5dda44dc2606f07ad86c9190fb54fd905f6d",
-                    "gas": "0xf4240",
-                    "gasPrice": "0x0"
-                }]),
-                res => json!("0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34");
-            "eth_blockNumber" =>
-                req => json!([]),
-                res => json!("0x1011");
-            "eth_blockNumber" =>
-                req => json!([]),
-                res => json!("0x1012");
-            "eth_blockNumber" =>
-                req => json!([]),
-                res => json!("0x1013");
-            "eth_getTransactionReceipt" =>
-                req => json!(["0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34"]),
-                res => json!(null);
-            "eth_blockNumber" =>
-                req => json!([]),
-                res => json!("0x1014");
-            "eth_getTransactionReceipt" =>
-                req => json!(["0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34"]),
-                res => json!({
-                    "blockHash": null,
-                    "blockNumber": null,
-                    "contractAddress": "0xb1ac3a5584519119419a8e56422d912c782d8e5b",
-                    "cumulativeGasUsed": "0x1c1999",
-                    "gasUsed": "0xcdb5d",
-                    "logs": [],
-                    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-                    "root": null,
-                    "status": "0x1",
-                    "transactionHash": "0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34",
-                    "transactionIndex":"0x4"
-                });
-            "eth_blockNumber" =>
-                req => json!([]),
-                res => json!("0x1014");
-            "eth_blockNumber" =>
-                req => json!([]),
-                res => json!("0x1015");
-            "eth_getTransactionReceipt" =>
-                req => json!(["0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34"]),
-                res => json!({
-                    "blockHash": "0xe0bdcf35b14a292d2998308d9b3fdea93a8c3d9c0b6c824c633fb9b15f9c3919",
-                    "blockNumber": "0x1015",
-                    "contractAddress": "0xb1ac3a5584519119419a8e56422d912c782d8e5b",
-                    "cumulativeGasUsed": "0x1c1999",
-                    "gasUsed": "0xcdb5d",
-                    "logs": [],
-                    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-                    "root": null,
-                    "status": "0x1",
-                    "transactionHash": "0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34",
-                    "transactionIndex":"0x4"
-                });
-            "eth_blockNumber" =>
-                req => json!([]),
-                res => json!("0x1017");
-            "eth_getTransactionReceipt" =>
-                req => json!(["0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34"]),
-                res => json!({
-                    "blockHash": "0xe0bdcf35b14a292d2998308d9b3fdea93a8c3d9c0b6c824c633fb9b15f9c3919",
-                    "blockNumber": "0x1015",
-                    "contractAddress": "0xb1ac3a5584519119419a8e56422d912c782d8e5b",
-                    "cumulativeGasUsed": "0x1c1999",
-                    "gasUsed": "0xcdb5d",
-                    "logs": [],
-                    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-                    "root": null,
-                    "status": "0x1",
-                    "transactionHash": "0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34",
-                    "transactionIndex":"0x4"
-                });
-        );
+	#[test]
+	fn test_send_tx_with_receipt() {
+		let transport = mock_transport!(
+			"eth_blockNumber" =>
+				req => json!([]),
+				res => json!("0x1010");
+			"eth_sendTransaction" =>
+				req => json!([{
+					"data": "0x60",
+					"from": "0x006b5dda44dc2606f07ad86c9190fb54fd905f6d",
+					"gas": "0xf4240",
+					"gasPrice": "0x0"
+				}]),
+				res => json!("0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34");
+			"eth_blockNumber" =>
+				req => json!([]),
+				res => json!("0x1011");
+			"eth_blockNumber" =>
+				req => json!([]),
+				res => json!("0x1012");
+			"eth_blockNumber" =>
+				req => json!([]),
+				res => json!("0x1013");
+			"eth_getTransactionReceipt" =>
+				req => json!(["0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34"]),
+				res => json!(null);
+			"eth_blockNumber" =>
+				req => json!([]),
+				res => json!("0x1014");
+			"eth_getTransactionReceipt" =>
+				req => json!(["0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34"]),
+				res => json!({
+					"blockHash": null,
+					"blockNumber": null,
+					"contractAddress": "0xb1ac3a5584519119419a8e56422d912c782d8e5b",
+					"cumulativeGasUsed": "0x1c1999",
+					"gasUsed": "0xcdb5d",
+					"logs": [],
+					"logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+					"root": null,
+					"status": "0x1",
+					"transactionHash": "0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34",
+					"transactionIndex":"0x4"
+				});
+			"eth_blockNumber" =>
+				req => json!([]),
+				res => json!("0x1014");
+			"eth_blockNumber" =>
+				req => json!([]),
+				res => json!("0x1015");
+			"eth_getTransactionReceipt" =>
+				req => json!(["0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34"]),
+				res => json!({
+					"blockHash": "0xe0bdcf35b14a292d2998308d9b3fdea93a8c3d9c0b6c824c633fb9b15f9c3919",
+					"blockNumber": "0x1015",
+					"contractAddress": "0xb1ac3a5584519119419a8e56422d912c782d8e5b",
+					"cumulativeGasUsed": "0x1c1999",
+					"gasUsed": "0xcdb5d",
+					"logs": [],
+					"logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+					"root": null,
+					"status": "0x1",
+					"transactionHash": "0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34",
+					"transactionIndex":"0x4"
+				});
+			"eth_blockNumber" =>
+				req => json!([]),
+				res => json!("0x1017");
+			"eth_getTransactionReceipt" =>
+				req => json!(["0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34"]),
+				res => json!({
+					"blockHash": "0xe0bdcf35b14a292d2998308d9b3fdea93a8c3d9c0b6c824c633fb9b15f9c3919",
+					"blockNumber": "0x1015",
+					"contractAddress": "0xb1ac3a5584519119419a8e56422d912c782d8e5b",
+					"cumulativeGasUsed": "0x1c1999",
+					"gasUsed": "0xcdb5d",
+					"logs": [],
+					"logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+					"root": null,
+					"status": "0x1",
+					"transactionHash": "0x36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34",
+					"transactionIndex":"0x4"
+				});
+		);
 
-        let send_transaction_with_receipt =
-            SendTransactionWithReceipt::new(SendTransactionWithReceiptOptions {
-                transport: transport.clone(),
-                request_timeout: Duration::from_secs(1),
-                poll_interval: Duration::from_secs(0),
-                confirmations: 2,
-                transaction: TransactionRequest {
-                    from: "006b5dda44dc2606f07ad86c9190fb54fd905f6d".parse().unwrap(),
-                    to: None,
-                    gas: Some(0xf4240.into()),
-                    gas_price: Some(0.into()),
-                    value: None,
-                    data: Some(vec![0x60].into()),
-                    nonce: None,
-                    condition: None,
-                },
-            });
+		let send_transaction_with_receipt =
+			SendTransactionWithReceipt::new(SendTransactionWithReceiptOptions {
+				transport: transport.clone(),
+				request_timeout: Duration::from_secs(1),
+				poll_interval: Duration::from_secs(0),
+				confirmations: 2,
+				transaction: TransactionRequest {
+					from: "006b5dda44dc2606f07ad86c9190fb54fd905f6d".parse().unwrap(),
+					to: None,
+					gas: Some(0xf4240.into()),
+					gas_price: Some(0.into()),
+					value: None,
+					data: Some(vec![0x60].into()),
+					nonce: None,
+					condition: None,
+				},
+			});
 
-        let mut event_loop = Core::new().unwrap();
-        let receipt = event_loop.run(send_transaction_with_receipt).unwrap();
-        assert_eq!(
-            receipt,
-            TransactionReceipt {
-                transaction_hash:
-                    "36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34"
-                        .parse()
-                        .unwrap(),
-                transaction_index: 0x4.into(),
-                block_hash: Some(
-                    "e0bdcf35b14a292d2998308d9b3fdea93a8c3d9c0b6c824c633fb9b15f9c3919"
-                        .parse()
-                        .unwrap()
-                ),
-                block_number: Some(0x1015.into()),
-                cumulative_gas_used: 0x1c1999.into(),
-                gas_used: "cdb5d".parse().ok(),
-                contract_address: Some("b1ac3a5584519119419a8e56422d912c782d8e5b".parse().unwrap()),
-                logs: vec![],
-                status: Some(1.into()),
-                logs_bloom: Default::default(),
-            }
-        );
-        assert_eq!(transport.actual_requests(), transport.expected_requests());
-    }
+		let mut event_loop = Core::new().unwrap();
+		let receipt = event_loop.run(send_transaction_with_receipt).unwrap();
+		assert_eq!(
+			receipt,
+			TransactionReceipt {
+				transaction_hash:
+					"36efc16910ea67a2425a1e75f7e39e3c6a94f5763c68a47258f552481e20cd34"
+						.parse()
+						.unwrap(),
+				transaction_index: 0x4.into(),
+				block_hash: Some(
+					"e0bdcf35b14a292d2998308d9b3fdea93a8c3d9c0b6c824c633fb9b15f9c3919"
+						.parse()
+						.unwrap()
+				),
+				block_number: Some(0x1015.into()),
+				cumulative_gas_used: 0x1c1999.into(),
+				gas_used: "cdb5d".parse().ok(),
+				contract_address: Some("b1ac3a5584519119419a8e56422d912c782d8e5b".parse().unwrap()),
+				logs: vec![],
+				status: Some(1.into()),
+				logs_bloom: Default::default(),
+			}
+		);
+		assert_eq!(transport.actual_requests(), transport.expected_requests());
+	}
 }

--- a/bridge/src/side_to_main_signatures.rs
+++ b/bridge/src/side_to_main_signatures.rs
@@ -29,21 +29,21 @@ use web3::types::{Log, H256};
 use web3::Transport;
 
 enum State<T: Transport> {
-    AwaitMessage(AsyncCall<T, contracts::side::functions::message::Decoder>),
-    AwaitIsRelayed {
-        future: AsyncCall<T, contracts::main::functions::accepted_messages::Decoder>,
-        message: MessageToMain,
-    },
-    AwaitSignatures {
-        future: JoinAll<Vec<AsyncCall<T, contracts::side::functions::signature::Decoder>>>,
-        message: MessageToMain,
-    },
-    AwaitMessageData {
-        future: AsyncCall<T, contracts::side::functions::relayed_messages::Decoder>,
-        message: MessageToMain,
-        signatures: Vec<Signature>,
-    },
-    AwaitTxSent(AsyncTransaction<T>),
+	AwaitMessage(AsyncCall<T, contracts::side::functions::message::Decoder>),
+	AwaitIsRelayed {
+		future: AsyncCall<T, contracts::main::functions::accepted_messages::Decoder>,
+		message: MessageToMain,
+	},
+	AwaitSignatures {
+		future: JoinAll<Vec<AsyncCall<T, contracts::side::functions::signature::Decoder>>>,
+		message: MessageToMain,
+	},
+	AwaitMessageData {
+		future: AsyncCall<T, contracts::side::functions::relayed_messages::Decoder>,
+		message: MessageToMain,
+		signatures: Vec<Signature>,
+	},
+	AwaitTxSent(AsyncTransaction<T>),
 }
 
 /// `Future` that completes a transfer from side to main by calling
@@ -51,419 +51,419 @@ enum State<T: Transport> {
 /// these get created by the `side_to_main_signatures` `RelayStream` that's part
 /// of the `Bridge`.
 pub struct SideToMainSignatures<T: Transport> {
-    side_tx_hash: H256,
-    main: MainContract<T>,
-    side: SideContract<T>,
-    state: State<T>,
+	side_tx_hash: H256,
+	main: MainContract<T>,
+	side: SideContract<T>,
+	state: State<T>,
 }
 
 impl<T: Transport> SideToMainSignatures<T> {
-    pub fn new(raw_log: &Log, main: MainContract<T>, side: SideContract<T>) -> Self {
-        let side_tx_hash = raw_log
-            .transaction_hash
-            .expect("`log` must be mined and contain `transaction_hash`. q.e.d.");
+	pub fn new(raw_log: &Log, main: MainContract<T>, side: SideContract<T>) -> Self {
+		let side_tx_hash = raw_log
+			.transaction_hash
+			.expect("`log` must be mined and contain `transaction_hash`. q.e.d.");
 
-        let log = helpers::parse_log(contracts::side::events::signed_message::parse_log, raw_log)
-            .expect("`Log` must be a from a `CollectedSignatures` event. q.e.d.");
+		let log = helpers::parse_log(contracts::side::events::signed_message::parse_log, raw_log)
+			.expect("`Log` must be a from a `CollectedSignatures` event. q.e.d.");
 
-        // authority_responsible_for_relay is an indexed topic and it should be
-        // always set up when creating the filter, so we receive only logs that
-        // we should relay
-        assert_eq!(
-            log.authority_responsible_for_relay, main.authority_address,
-            "incorrectly set up collected_signatures filter, we should only received logs where authority_responsible_for_relay == main.authority_address; qed"
-        );
+		// authority_responsible_for_relay is an indexed topic and it should be
+		// always set up when creating the filter, so we receive only logs that
+		// we should relay
+		assert_eq!(
+			log.authority_responsible_for_relay, main.authority_address,
+			"incorrectly set up collected_signatures filter, we should only received logs where authority_responsible_for_relay == main.authority_address; qed"
+		);
 
-        info!("{:?} - step 1/3 - about to fetch message", side_tx_hash,);
-        let (payload, decoder) = contracts::side::functions::message::call(log.message_hash);
-        let state = State::AwaitMessage(side.call(payload, decoder));
+		info!("{:?} - step 1/3 - about to fetch message", side_tx_hash,);
+		let (payload, decoder) = contracts::side::functions::message::call(log.message_hash);
+		let state = State::AwaitMessage(side.call(payload, decoder));
 
-        Self {
-            side_tx_hash,
-            main,
-            side,
-            state,
-        }
-    }
+		Self {
+			side_tx_hash,
+			main,
+			side,
+			state,
+		}
+	}
 }
 
 impl<T: Transport> Future for SideToMainSignatures<T> {
-    type Item = Option<H256>;
-    type Error = error::Error;
+	type Item = Option<H256>;
+	type Error = error::Error;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        loop {
-            let next_state = match self.state {
-                State::AwaitMessage(ref mut future) => {
-                    let message_bytes = try_ready!(future
-                        .poll()
-                        .chain_err(|| "SubmitSignature: fetching message failed"));
-                    let message = MessageToMain::from_bytes(&message_bytes)?;
+	fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+		loop {
+			let next_state = match self.state {
+				State::AwaitMessage(ref mut future) => {
+					let message_bytes = try_ready!(future
+						.poll()
+						.chain_err(|| "SubmitSignature: fetching message failed"));
+					let message = MessageToMain::from_bytes(&message_bytes)?;
 
-                    let (payload, decoder) =
-                        contracts::main::functions::accepted_messages::call(message.keccak256());
-                    State::AwaitIsRelayed {
-                        future: self.main.call(payload, decoder),
-                        message,
-                    }
-                }
-                State::AwaitIsRelayed {
-                    ref mut future,
-                    ref message,
-                } => {
-                    let is_relayed = try_ready!(future
-                        .poll()
-                        .chain_err(|| "SubmitSignature: fetching message failed"));
+					let (payload, decoder) =
+						contracts::main::functions::accepted_messages::call(message.keccak256());
+					State::AwaitIsRelayed {
+						future: self.main.call(payload, decoder),
+						message,
+					}
+				}
+				State::AwaitIsRelayed {
+					ref mut future,
+					ref message,
+				} => {
+					let is_relayed = try_ready!(future
+						.poll()
+						.chain_err(|| "SubmitSignature: fetching message failed"));
 
-                    if is_relayed {
-                        return Ok(Async::Ready(None));
-                    }
+					if is_relayed {
+						return Ok(Async::Ready(None));
+					}
 
-                    State::AwaitSignatures {
-                        future: self.side.get_signatures(message.keccak256()),
-                        message: message.clone(),
-                    }
-                }
-                State::AwaitSignatures {
-                    ref mut future,
-                    ref message,
-                } => {
-                    let raw_signatures = try_ready!(future
-                        .poll()
-                        .chain_err(|| "WithdrawRelay: fetching message and signatures failed"));
-                    let signatures: Vec<Signature> = raw_signatures
-                        .iter()
-                        .map(|x| Signature::from_bytes(x))
-                        .collect::<Result<_, _>>()?;
-                    info!("{:?} - step 2/3 - message and {} signatures received. about to send transaction", self.side_tx_hash, signatures.len());
+					State::AwaitSignatures {
+						future: self.side.get_signatures(message.keccak256()),
+						message: message.clone(),
+					}
+				}
+				State::AwaitSignatures {
+					ref mut future,
+					ref message,
+				} => {
+					let raw_signatures = try_ready!(future
+						.poll()
+						.chain_err(|| "WithdrawRelay: fetching message and signatures failed"));
+					let signatures: Vec<Signature> = raw_signatures
+						.iter()
+						.map(|x| Signature::from_bytes(x))
+						.collect::<Result<_, _>>()?;
+					info!("{:?} - step 2/3 - message and {} signatures received. about to send transaction", self.side_tx_hash, signatures.len());
 
-                    let (payload, decoder) =
-                        contracts::side::functions::relayed_messages::call(message.message_id);
-                    State::AwaitMessageData {
-                        future: self.side.call(payload, decoder),
-                        message: message.clone(),
-                        signatures,
-                    }
-                }
-                State::AwaitMessageData {
-                    ref mut future,
-                    ref message,
-                    ref signatures,
-                } => {
-                    let message_data = try_ready!(future
-                        .poll()
-                        .chain_err(|| "SubmitSignature: fetching message failed"));
+					let (payload, decoder) =
+						contracts::side::functions::relayed_messages::call(message.message_id);
+					State::AwaitMessageData {
+						future: self.side.call(payload, decoder),
+						message: message.clone(),
+						signatures,
+					}
+				}
+				State::AwaitMessageData {
+					ref mut future,
+					ref message,
+					ref signatures,
+				} => {
+					let message_data = try_ready!(future
+						.poll()
+						.chain_err(|| "SubmitSignature: fetching message failed"));
 
-                    State::AwaitTxSent(self.main.relay_side_to_main(
-                        &message,
-                        &signatures,
-                        message_data,
-                    ))
-                }
-                State::AwaitTxSent(ref mut future) => {
-                    let main_tx_hash = try_ready!(future
-                        .poll()
-                        .chain_err(|| "WithdrawRelay: sending transaction failed"));
-                    info!(
-                        "{:?} - step 3/3 - DONE - transaction sent {:?}",
-                        self.side_tx_hash, main_tx_hash
-                    );
-                    return Ok(Async::Ready(Some(main_tx_hash)));
-                }
-            };
-            self.state = next_state;
-        }
-    }
+					State::AwaitTxSent(self.main.relay_side_to_main(
+						&message,
+						&signatures,
+						message_data,
+					))
+				}
+				State::AwaitTxSent(ref mut future) => {
+					let main_tx_hash = try_ready!(future
+						.poll()
+						.chain_err(|| "WithdrawRelay: sending transaction failed"));
+					info!(
+						"{:?} - step 3/3 - DONE - transaction sent {:?}",
+						self.side_tx_hash, main_tx_hash
+					);
+					return Ok(Async::Ready(Some(main_tx_hash)));
+				}
+			};
+			self.state = next_state;
+		}
+	}
 }
 
 /// options for relays from side to main
 pub struct LogToSideToMainSignatures<T> {
-    pub main: MainContract<T>,
-    pub side: SideContract<T>,
+	pub main: MainContract<T>,
+	pub side: SideContract<T>,
 }
 
 /// from the options and a log a relay future can be made
 impl<T: Transport> LogToFuture for LogToSideToMainSignatures<T> {
-    type Future = SideToMainSignatures<T>;
+	type Future = SideToMainSignatures<T>;
 
-    fn log_to_future(&self, log: &Log) -> Self::Future {
-        SideToMainSignatures::new(log, self.main.clone(), self.side.clone())
-    }
+	fn log_to_future(&self, log: &Log) -> Self::Future {
+		SideToMainSignatures::new(log, self.main.clone(), self.side.clone())
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use contracts;
-    use ethabi;
-    use rustc_hex::FromHex;
-    use rustc_hex::ToHex;
-    use tokio_core::reactor::Core;
-    use web3::types::{Address, Bytes, Log};
+	use super::*;
+	use contracts;
+	use ethabi;
+	use rustc_hex::FromHex;
+	use rustc_hex::ToHex;
+	use tokio_core::reactor::Core;
+	use web3::types::{Address, Bytes, Log};
 
-    #[test]
-    fn test_side_to_main_sign_relay_future_not_relayed_authority_responsible() {
-        let authority_address: Address =
-            "0000000000000000000000000000000000000001".parse().unwrap();
-        let authority_responsible_for_relay = authority_address;
-        let topic =
-            contracts::side::events::signed_message::filter(authority_responsible_for_relay);
+	#[test]
+	fn test_side_to_main_sign_relay_future_not_relayed_authority_responsible() {
+		let authority_address: Address =
+			"0000000000000000000000000000000000000001".parse().unwrap();
+		let authority_responsible_for_relay = authority_address;
+		let topic =
+			contracts::side::events::signed_message::filter(authority_responsible_for_relay);
 
-        let message = MessageToMain {
-            side_tx_hash: "884edad9ce6fa2440d8a54cc123490eb96d2768479d49ff9c7366125a9424364"
-                .parse()
-                .unwrap(),
-            message_id: "884edad9ce6fa2440d8a54cc123490eb96d2768479d49ff9c7366125a94243ff"
-                .parse()
-                .unwrap(),
-            sender: "aff3454fce5edbc8cca8697c15331677e6ebccff".parse().unwrap(),
-            recipient: "aff3454fce5edbc8cca8697c15331677e6ebcccc".parse().unwrap(),
-        };
+		let message = MessageToMain {
+			side_tx_hash: "884edad9ce6fa2440d8a54cc123490eb96d2768479d49ff9c7366125a9424364"
+				.parse()
+				.unwrap(),
+			message_id: "884edad9ce6fa2440d8a54cc123490eb96d2768479d49ff9c7366125a94243ff"
+				.parse()
+				.unwrap(),
+			sender: "aff3454fce5edbc8cca8697c15331677e6ebccff".parse().unwrap(),
+			recipient: "aff3454fce5edbc8cca8697c15331677e6ebcccc".parse().unwrap(),
+		};
 
-        let log = contracts::side::logs::SignedMessage {
-            authority_responsible_for_relay,
-            message_hash: message.keccak256(),
-        };
+		let log = contracts::side::logs::SignedMessage {
+			authority_responsible_for_relay,
+			message_hash: message.keccak256(),
+		};
 
-        // TODO [snd] would be nice if ethabi derived log structs implemented `encode`
-        let log_data = ethabi::encode(&[ethabi::Token::FixedBytes(
-            log.message_hash.as_bytes().to_vec(),
-        )]);
+		// TODO [snd] would be nice if ethabi derived log structs implemented `encode`
+		let log_data = ethabi::encode(&[ethabi::Token::FixedBytes(
+			log.message_hash.as_bytes().to_vec(),
+		)]);
 
-        let log_tx_hash: H256 = "884edad9ce6fa2440d8a54cc123490eb96d2768479d49ff9c7366125a9424364"
-            .parse()
-            .unwrap();
+		let log_tx_hash: H256 = "884edad9ce6fa2440d8a54cc123490eb96d2768479d49ff9c7366125a9424364"
+			.parse()
+			.unwrap();
 
-        let raw_log = Log {
-            address: "0000000000000000000000000000000000000001".parse().unwrap(),
-            topics: vec![topic.topic0[0], topic.topic1[0]],
-            data: Bytes(log_data),
-            transaction_hash: Some(log_tx_hash),
-            block_hash: None,
-            block_number: None,
-            transaction_index: None,
-            log_index: None,
-            transaction_log_index: None,
-            log_type: None,
-            removed: None,
-        };
+		let raw_log = Log {
+			address: "0000000000000000000000000000000000000001".parse().unwrap(),
+			topics: vec![topic.topic0[0], topic.topic1[0]],
+			data: Bytes(log_data),
+			transaction_hash: Some(log_tx_hash),
+			block_hash: None,
+			block_number: None,
+			transaction_index: None,
+			log_index: None,
+			transaction_log_index: None,
+			log_type: None,
+			removed: None,
+		};
 
-        let side_contract_address: Address =
-            "0000000000000000000000000000000000000dd1".parse().unwrap();
-        let main_contract_address: Address =
-            "0000000000000000000000000000000000000fff".parse().unwrap();
+		let side_contract_address: Address =
+			"0000000000000000000000000000000000000dd1".parse().unwrap();
+		let main_contract_address: Address =
+			"0000000000000000000000000000000000000fff".parse().unwrap();
 
-        let sig: Vec<u8> = "8697c15331677e6ebccccaff3454fce5edbc8cca8697c15331677aff3454fce5edbc8cca8697c15331677e6ebccccaff3454fce5edbc8cca8697c15331677e6ebc"
-            .from_hex()
-            .unwrap();
-        let signature = Signature::from_bytes(&*sig).unwrap();
+		let sig: Vec<u8> = "8697c15331677e6ebccccaff3454fce5edbc8cca8697c15331677aff3454fce5edbc8cca8697c15331677e6ebccccaff3454fce5edbc8cca8697c15331677e6ebc"
+			.from_hex()
+			.unwrap();
+		let signature = Signature::from_bytes(&*sig).unwrap();
 
-        let tx_hash = "1db8f385535c0d178b8f40016048f3a3cffee8f94e68978ea4b277f57b638f0b";
-        let data: Vec<u8> = vec![10, 0];
+		let tx_hash = "1db8f385535c0d178b8f40016048f3a3cffee8f94e68978ea4b277f57b638f0b";
+		let data: Vec<u8> = vec![10, 0];
 
-        let main_transport = mock_transport!(
-            "eth_call" =>
-                req => json!([{
-                    "data": format!("0x{}", contracts::main::functions::accepted_messages::encode_input(log.message_hash).to_hex::<String>()),
-                    "to": format!("0x{:x}", main_contract_address),
-                }, "latest"]),
-                res => json!(format!("0x{}", ethabi::encode(&[ethabi::Token::Bool(false)]).to_hex::<String>()));
-            "eth_sendTransaction" =>
-                req => json!([{
-                    "data": format!(
-                        "0x{}",
-                        contracts::main::functions::accept_message::encode_input(
-                            vec![signature.v],
-                            vec![signature.r.clone()],
-                            vec![signature.s.clone()],
-                            message.side_tx_hash,
-                            data.clone(),
-                            message.sender,
-                            message.recipient,
-                        ).to_hex::<String>()
-                    ),
-                    "from": format!("0x{:x}", authority_address),
-                    "gas": "0xfd",
-                    // TODO: fix gasPrice
-                    "gasPrice": format!("0x{:x}", 1000),
-                    "to": format!("0x{:x}", main_contract_address),
-                }]),
-                res => json!(format!("0x{:}", tx_hash));
-        );
+		let main_transport = mock_transport!(
+			"eth_call" =>
+				req => json!([{
+					"data": format!("0x{}", contracts::main::functions::accepted_messages::encode_input(log.message_hash).to_hex::<String>()),
+					"to": format!("0x{:x}", main_contract_address),
+				}, "latest"]),
+				res => json!(format!("0x{}", ethabi::encode(&[ethabi::Token::Bool(false)]).to_hex::<String>()));
+			"eth_sendTransaction" =>
+				req => json!([{
+					"data": format!(
+						"0x{}",
+						contracts::main::functions::accept_message::encode_input(
+							vec![signature.v],
+							vec![signature.r.clone()],
+							vec![signature.s.clone()],
+							message.side_tx_hash,
+							data.clone(),
+							message.sender,
+							message.recipient,
+						).to_hex::<String>()
+					),
+					"from": format!("0x{:x}", authority_address),
+					"gas": "0xfd",
+					// TODO: fix gasPrice
+					"gasPrice": format!("0x{:x}", 1000),
+					"to": format!("0x{:x}", main_contract_address),
+				}]),
+				res => json!(format!("0x{:}", tx_hash));
+		);
 
-        let side_transport = mock_transport!(
-            "eth_call" =>
-                req => json!([{
-                    "data": format!("0x{}",
-                                    contracts::side::functions::message::encode_input(log.message_hash).to_hex::<String>()),
-                    "to": format!("0x{:x}", side_contract_address),
-                }, "latest"]),
-                res => json!(format!("0x{}",
-                                     ethabi::encode(&[ethabi::Token::Bytes(message.to_bytes())]).to_hex::<String>()));
-            "eth_call" =>
-                req => json!([{
-                    "data": format!("0x{}", contracts::side::functions::signature::encode_input(log.message_hash, 0).to_hex::<String>()),
-                    "to": format!("0x{:x}", side_contract_address),
-                }, "latest"]),
-                res => json!(format!("0x{}",
-                                     ethabi::encode(&[ethabi::Token::Bytes(signature.to_bytes())]).to_hex::<String>()));
-            "eth_call" =>
-                req => json!([{
-                    "data": format!("0x{}", contracts::side::functions::relayed_messages::encode_input(message.message_id).to_hex::<String>()),
-                    "to": format!("0x{:x}", side_contract_address),
-                }, "latest"]),
-                res => json!(format!("0x{}", ethabi::encode(&[ethabi::Token::Bytes(data)]).to_hex::<String>()));
-        );
+		let side_transport = mock_transport!(
+			"eth_call" =>
+				req => json!([{
+					"data": format!("0x{}",
+									contracts::side::functions::message::encode_input(log.message_hash).to_hex::<String>()),
+					"to": format!("0x{:x}", side_contract_address),
+				}, "latest"]),
+				res => json!(format!("0x{}",
+									 ethabi::encode(&[ethabi::Token::Bytes(message.to_bytes())]).to_hex::<String>()));
+			"eth_call" =>
+				req => json!([{
+					"data": format!("0x{}", contracts::side::functions::signature::encode_input(log.message_hash, 0).to_hex::<String>()),
+					"to": format!("0x{:x}", side_contract_address),
+				}, "latest"]),
+				res => json!(format!("0x{}",
+									 ethabi::encode(&[ethabi::Token::Bytes(signature.to_bytes())]).to_hex::<String>()));
+			"eth_call" =>
+				req => json!([{
+					"data": format!("0x{}", contracts::side::functions::relayed_messages::encode_input(message.message_id).to_hex::<String>()),
+					"to": format!("0x{:x}", side_contract_address),
+				}, "latest"]),
+				res => json!(format!("0x{}", ethabi::encode(&[ethabi::Token::Bytes(data)]).to_hex::<String>()));
+		);
 
-        let main_contract = MainContract {
-            transport: main_transport.clone(),
-            contract_address: main_contract_address,
-            authority_address,
-            request_timeout: ::std::time::Duration::from_millis(0),
-            logs_poll_interval: ::std::time::Duration::from_millis(0),
-            required_log_confirmations: 0,
-            submit_collected_signatures_gas: 0xfd.into(),
-        };
+		let main_contract = MainContract {
+			transport: main_transport.clone(),
+			contract_address: main_contract_address,
+			authority_address,
+			request_timeout: ::std::time::Duration::from_millis(0),
+			logs_poll_interval: ::std::time::Duration::from_millis(0),
+			required_log_confirmations: 0,
+			submit_collected_signatures_gas: 0xfd.into(),
+		};
 
-        let side_contract = SideContract {
-            transport: side_transport.clone(),
-            contract_address: side_contract_address,
-            authority_address,
-            required_signatures: 1,
-            request_timeout: ::std::time::Duration::from_millis(0),
-            logs_poll_interval: ::std::time::Duration::from_millis(0),
-            required_log_confirmations: 0,
-            sign_main_to_side_gas: 0.into(),
-            sign_main_to_side_gas_price: 0.into(),
-            sign_side_to_main_gas: 0xfd.into(),
-            sign_side_to_main_gas_price: 0xa0.into(),
-        };
+		let side_contract = SideContract {
+			transport: side_transport.clone(),
+			contract_address: side_contract_address,
+			authority_address,
+			required_signatures: 1,
+			request_timeout: ::std::time::Duration::from_millis(0),
+			logs_poll_interval: ::std::time::Duration::from_millis(0),
+			required_log_confirmations: 0,
+			sign_main_to_side_gas: 0.into(),
+			sign_main_to_side_gas_price: 0.into(),
+			sign_side_to_main_gas: 0xfd.into(),
+			sign_side_to_main_gas_price: 0xa0.into(),
+		};
 
-        let future = SideToMainSignatures::new(&raw_log, main_contract, side_contract);
+		let future = SideToMainSignatures::new(&raw_log, main_contract, side_contract);
 
-        let mut event_loop = Core::new().unwrap();
-        let result = event_loop.run(future).unwrap();
-        assert_eq!(result, Some(tx_hash.parse().unwrap()));
+		let mut event_loop = Core::new().unwrap();
+		let result = event_loop.run(future).unwrap();
+		assert_eq!(result, Some(tx_hash.parse().unwrap()));
 
-        assert_eq!(
-            main_transport.actual_requests(),
-            main_transport.expected_requests()
-        );
-        assert_eq!(
-            side_transport.actual_requests(),
-            side_transport.expected_requests()
-        );
-    }
+		assert_eq!(
+			main_transport.actual_requests(),
+			main_transport.expected_requests()
+		);
+		assert_eq!(
+			side_transport.actual_requests(),
+			side_transport.expected_requests()
+		);
+	}
 
-    #[test]
-    fn test_side_to_main_sign_relay_future_already_relayed() {
-        let authority_address: Address =
-            "0000000000000000000000000000000000000001".parse().unwrap();
-        let authority_responsible_for_relay = authority_address;
-        let topic =
-            contracts::side::events::signed_message::filter(authority_responsible_for_relay);
+	#[test]
+	fn test_side_to_main_sign_relay_future_already_relayed() {
+		let authority_address: Address =
+			"0000000000000000000000000000000000000001".parse().unwrap();
+		let authority_responsible_for_relay = authority_address;
+		let topic =
+			contracts::side::events::signed_message::filter(authority_responsible_for_relay);
 
-        let message = MessageToMain {
-            side_tx_hash: "884edad9ce6fa2440d8a54cc123490eb96d2768479d49ff9c7366125a9424364"
-                .parse()
-                .unwrap(),
-            message_id: "884edad9ce6fa2440d8a54cc123490eb96d2768479d49ff9c7366125a94243ff"
-                .parse()
-                .unwrap(),
-            sender: "aff3454fce5edbc8cca8697c15331677e6ebccff".parse().unwrap(),
-            recipient: "aff3454fce5edbc8cca8697c15331677e6ebcccc".parse().unwrap(),
-        };
+		let message = MessageToMain {
+			side_tx_hash: "884edad9ce6fa2440d8a54cc123490eb96d2768479d49ff9c7366125a9424364"
+				.parse()
+				.unwrap(),
+			message_id: "884edad9ce6fa2440d8a54cc123490eb96d2768479d49ff9c7366125a94243ff"
+				.parse()
+				.unwrap(),
+			sender: "aff3454fce5edbc8cca8697c15331677e6ebccff".parse().unwrap(),
+			recipient: "aff3454fce5edbc8cca8697c15331677e6ebcccc".parse().unwrap(),
+		};
 
-        let log = contracts::side::logs::SignedMessage {
-            authority_responsible_for_relay,
-            message_hash: message.keccak256(),
-        };
+		let log = contracts::side::logs::SignedMessage {
+			authority_responsible_for_relay,
+			message_hash: message.keccak256(),
+		};
 
-        // TODO [snd] would be nice if ethabi derived log structs implemented `encode`
-        let log_data = ethabi::encode(&[ethabi::Token::FixedBytes(
-            log.message_hash.as_bytes().to_vec(),
-        )]);
+		// TODO [snd] would be nice if ethabi derived log structs implemented `encode`
+		let log_data = ethabi::encode(&[ethabi::Token::FixedBytes(
+			log.message_hash.as_bytes().to_vec(),
+		)]);
 
-        let log_tx_hash: H256 = "884edad9ce6fa2440d8a54cc123490eb96d2768479d49ff9c7366125a9424364"
-            .parse()
-            .unwrap();
+		let log_tx_hash: H256 = "884edad9ce6fa2440d8a54cc123490eb96d2768479d49ff9c7366125a9424364"
+			.parse()
+			.unwrap();
 
-        let raw_log = Log {
-            address: "0000000000000000000000000000000000000001".parse().unwrap(),
-            topics: vec![topic.topic0[0], topic.topic1[0]],
-            data: Bytes(log_data),
-            transaction_hash: Some(log_tx_hash),
-            block_hash: None,
-            block_number: None,
-            transaction_index: None,
-            log_index: None,
-            transaction_log_index: None,
-            log_type: None,
-            removed: None,
-        };
+		let raw_log = Log {
+			address: "0000000000000000000000000000000000000001".parse().unwrap(),
+			topics: vec![topic.topic0[0], topic.topic1[0]],
+			data: Bytes(log_data),
+			transaction_hash: Some(log_tx_hash),
+			block_hash: None,
+			block_number: None,
+			transaction_index: None,
+			log_index: None,
+			transaction_log_index: None,
+			log_type: None,
+			removed: None,
+		};
 
-        let side_contract_address: Address =
-            "0000000000000000000000000000000000000dd1".parse().unwrap();
-        let main_contract_address: Address =
-            "0000000000000000000000000000000000000fff".parse().unwrap();
+		let side_contract_address: Address =
+			"0000000000000000000000000000000000000dd1".parse().unwrap();
+		let main_contract_address: Address =
+			"0000000000000000000000000000000000000fff".parse().unwrap();
 
-        let main_transport = mock_transport!(
-            "eth_call" =>
-                req => json!([{
-                    "data": format!("0x{}", contracts::main::functions::accepted_messages::encode_input(log.message_hash).to_hex::<String>()),
-                    "to": main_contract_address,
-                }, "latest"]),
-                res => json!(format!("0x{}", ethabi::encode(&[ethabi::Token::Bool(true)]).to_hex::<String>()));
-        );
+		let main_transport = mock_transport!(
+			"eth_call" =>
+				req => json!([{
+					"data": format!("0x{}", contracts::main::functions::accepted_messages::encode_input(log.message_hash).to_hex::<String>()),
+					"to": main_contract_address,
+				}, "latest"]),
+				res => json!(format!("0x{}", ethabi::encode(&[ethabi::Token::Bool(true)]).to_hex::<String>()));
+		);
 
-        let side_transport = mock_transport!(
-            "eth_call" =>
-                req => json!([{
-                    "data": format!("0x{}",
-                                    contracts::side::functions::message::encode_input(log.message_hash).to_hex::<String>()),
-                    "to": side_contract_address,
-                }, "latest"]),
-                res => json!(format!("0x{}",
-                                     ethabi::encode(&[ethabi::Token::Bytes(message.to_bytes())]).to_hex::<String>()));
-        );
+		let side_transport = mock_transport!(
+			"eth_call" =>
+				req => json!([{
+					"data": format!("0x{}",
+									contracts::side::functions::message::encode_input(log.message_hash).to_hex::<String>()),
+					"to": side_contract_address,
+				}, "latest"]),
+				res => json!(format!("0x{}",
+									 ethabi::encode(&[ethabi::Token::Bytes(message.to_bytes())]).to_hex::<String>()));
+		);
 
-        let main_contract = MainContract {
-            transport: main_transport.clone(),
-            contract_address: main_contract_address,
-            authority_address,
-            request_timeout: ::std::time::Duration::from_millis(0),
-            logs_poll_interval: ::std::time::Duration::from_millis(0),
-            required_log_confirmations: 0,
-            submit_collected_signatures_gas: 0xfd.into(),
-        };
+		let main_contract = MainContract {
+			transport: main_transport.clone(),
+			contract_address: main_contract_address,
+			authority_address,
+			request_timeout: ::std::time::Duration::from_millis(0),
+			logs_poll_interval: ::std::time::Duration::from_millis(0),
+			required_log_confirmations: 0,
+			submit_collected_signatures_gas: 0xfd.into(),
+		};
 
-        let side_contract = SideContract {
-            transport: side_transport.clone(),
-            contract_address: side_contract_address,
-            authority_address,
-            required_signatures: 1,
-            request_timeout: ::std::time::Duration::from_millis(0),
-            logs_poll_interval: ::std::time::Duration::from_millis(0),
-            required_log_confirmations: 0,
-            sign_main_to_side_gas: 0.into(),
-            sign_main_to_side_gas_price: 0.into(),
-            sign_side_to_main_gas: 0xfd.into(),
-            sign_side_to_main_gas_price: 0xa0.into(),
-        };
+		let side_contract = SideContract {
+			transport: side_transport.clone(),
+			contract_address: side_contract_address,
+			authority_address,
+			required_signatures: 1,
+			request_timeout: ::std::time::Duration::from_millis(0),
+			logs_poll_interval: ::std::time::Duration::from_millis(0),
+			required_log_confirmations: 0,
+			sign_main_to_side_gas: 0.into(),
+			sign_main_to_side_gas_price: 0.into(),
+			sign_side_to_main_gas: 0xfd.into(),
+			sign_side_to_main_gas_price: 0xa0.into(),
+		};
 
-        let future = SideToMainSignatures::new(&raw_log, main_contract, side_contract);
+		let future = SideToMainSignatures::new(&raw_log, main_contract, side_contract);
 
-        let mut event_loop = Core::new().unwrap();
-        let result = event_loop.run(future).unwrap();
-        assert_eq!(result, None);
+		let mut event_loop = Core::new().unwrap();
+		let result = event_loop.run(future).unwrap();
+		assert_eq!(result, None);
 
-        assert_eq!(
-            main_transport.actual_requests(),
-            main_transport.expected_requests()
-        );
-        assert_eq!(
-            side_transport.actual_requests(),
-            side_transport.expected_requests()
-        );
-    }
+		assert_eq!(
+			main_transport.actual_requests(),
+			main_transport.expected_requests()
+		);
+		assert_eq!(
+			side_transport.actual_requests(),
+			side_transport.expected_requests()
+		);
+	}
 }

--- a/bridge/src/signature.rs
+++ b/bridge/src/signature.rs
@@ -26,66 +26,66 @@ pub const SIGNATURE_LENGTH: usize = 65;
 /// an ECDSA signature consisting of `v`, `r` and `s`
 #[derive(PartialEq, Debug)]
 pub struct Signature {
-    pub v: u8,
-    pub r: H256,
-    pub s: H256,
+	pub v: u8,
+	pub r: H256,
+	pub s: H256,
 }
 
 impl Signature {
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        if bytes.len() != SIGNATURE_LENGTH {
-            bail!("`bytes`.len() must be {}", SIGNATURE_LENGTH);
-        }
+	pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+		if bytes.len() != SIGNATURE_LENGTH {
+			bail!("`bytes`.len() must be {}", SIGNATURE_LENGTH);
+		}
 
-        Ok(Self {
-            v: bytes[64],
-            r: H256::from_slice(&bytes[0..32]),
-            s: H256::from_slice(&bytes[32..64]),
-        })
-    }
+		Ok(Self {
+			v: bytes[64],
+			r: H256::from_slice(&bytes[0..32]),
+			s: H256::from_slice(&bytes[32..64]),
+		})
+	}
 
-    pub fn to_bytes(&self) -> Vec<u8> {
-        let mut result = vec![0u8; SIGNATURE_LENGTH];
-        result[0..32].copy_from_slice(&self.r.0[..]);
-        result[32..64].copy_from_slice(&self.s.0[..]);
-        result[64] = self.v;
-        return result;
-    }
+	pub fn to_bytes(&self) -> Vec<u8> {
+		let mut result = vec![0u8; SIGNATURE_LENGTH];
+		result[0..32].copy_from_slice(&self.r.0[..]);
+		result[32..64].copy_from_slice(&self.s.0[..]);
+		result[64] = self.v;
+		return result;
+	}
 
-    pub fn to_payload(&self) -> Vec<u8> {
-        ethabi::encode(&[ethabi::Token::Bytes(self.to_bytes())])
-    }
+	pub fn to_payload(&self) -> Vec<u8> {
+		ethabi::encode(&[ethabi::Token::Bytes(self.to_bytes())])
+	}
 }
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use quickcheck::TestResult;
+	use super::*;
+	use quickcheck::TestResult;
 
-    quickcheck! {
-        fn quickcheck_signature_roundtrips(v: u8, r_raw: Vec<u8>, s_raw: Vec<u8>) -> TestResult {
-            if r_raw.len() != 32 || s_raw.len() != 32 {
-                return TestResult::discard();
-            }
+	quickcheck! {
+		fn quickcheck_signature_roundtrips(v: u8, r_raw: Vec<u8>, s_raw: Vec<u8>) -> TestResult {
+			if r_raw.len() != 32 || s_raw.len() != 32 {
+				return TestResult::discard();
+			}
 
-            let r = H256::from_slice(r_raw.as_slice());
-            let s = H256::from_slice(s_raw.as_slice());
-            let signature = Signature { v, r, s };
-            assert_eq!(v, signature.v);
-            assert_eq!(r, signature.r);
-            assert_eq!(s, signature.s);
+			let r = H256::from_slice(r_raw.as_slice());
+			let s = H256::from_slice(s_raw.as_slice());
+			let signature = Signature { v, r, s };
+			assert_eq!(v, signature.v);
+			assert_eq!(r, signature.r);
+			assert_eq!(s, signature.s);
 
-            let bytes = signature.to_bytes();
+			let bytes = signature.to_bytes();
 
-            assert_eq!(signature, Signature::from_bytes(bytes.as_slice()).unwrap());
+			assert_eq!(signature, Signature::from_bytes(bytes.as_slice()).unwrap());
 
-            let payload = signature.to_payload();
-            let mut tokens = ethabi::decode(&[ethabi::ParamType::Bytes], payload.as_slice())
-                .unwrap();
-            let decoded = tokens.pop().unwrap().to_bytes().unwrap();
-            assert_eq!(signature, Signature::from_bytes(decoded.as_slice()).unwrap());
+			let payload = signature.to_payload();
+			let mut tokens = ethabi::decode(&[ethabi::ParamType::Bytes], payload.as_slice())
+				.unwrap();
+			let decoded = tokens.pop().unwrap().to_bytes().unwrap();
+			assert_eq!(signature, Signature::from_bytes(decoded.as_slice()).unwrap());
 
-            TestResult::passed()
-        }
-    }
+			TestResult::passed()
+		}
+	}
 }

--- a/bridge/src/test.rs
+++ b/bridge/src/test.rs
@@ -26,102 +26,102 @@ use web3::Transport;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct RequestData {
-    pub method: String,
-    pub params: Vec<jsonrpc_core::Value>,
+	pub method: String,
+	pub params: Vec<jsonrpc_core::Value>,
 }
 
 impl From<(&'static str, serde_json::Value)> for RequestData {
-    fn from(a: (&'static str, serde_json::Value)) -> Self {
-        Self {
-            method: a.0.to_owned(),
-            params: a.1.as_array().unwrap().clone(),
-        }
-    }
+	fn from(a: (&'static str, serde_json::Value)) -> Self {
+		Self {
+			method: a.0.to_owned(),
+			params: a.1.as_array().unwrap().clone(),
+		}
+	}
 }
 
 /// a `Transport` that and will return the specified responses
 /// `clone`d versions have the same storage
 #[derive(Debug, Clone)]
 pub struct MockTransport {
-    pub expected_requests: Vec<RequestData>,
-    pub actual_requests: Rc<RefCell<Vec<RequestData>>>,
-    pub mock_responses: Vec<serde_json::Value>,
+	pub expected_requests: Vec<RequestData>,
+	pub actual_requests: Rc<RefCell<Vec<RequestData>>>,
+	pub mock_responses: Vec<serde_json::Value>,
 }
 
 impl MockTransport {
-    pub fn expected_requests(&self) -> Vec<RequestData> {
-        self.expected_requests.clone()
-    }
-    pub fn actual_requests(&self) -> Vec<RequestData> {
-        self.actual_requests.as_ref().borrow().clone()
-    }
+	pub fn expected_requests(&self) -> Vec<RequestData> {
+		self.expected_requests.clone()
+	}
+	pub fn actual_requests(&self) -> Vec<RequestData> {
+		self.actual_requests.as_ref().borrow().clone()
+	}
 }
 
 impl Transport for MockTransport {
-    type Out = web3::Result<jsonrpc_core::Value>;
+	type Out = web3::Result<jsonrpc_core::Value>;
 
-    fn prepare(
-        &self,
-        method: &str,
-        params: Vec<jsonrpc_core::Value>,
-    ) -> (usize, jsonrpc_core::Call) {
-        let current_request_index = { self.actual_requests.as_ref().borrow().len() };
-        assert!(
-            current_request_index < self.expected_requests.len(),
-            "{} requests expected but at least one more request is being executed",
-            self.expected_requests.len()
-        );
+	fn prepare(
+		&self,
+		method: &str,
+		params: Vec<jsonrpc_core::Value>,
+	) -> (usize, jsonrpc_core::Call) {
+		let current_request_index = { self.actual_requests.as_ref().borrow().len() };
+		assert!(
+			current_request_index < self.expected_requests.len(),
+			"{} requests expected but at least one more request is being executed",
+			self.expected_requests.len()
+		);
 
-        assert_eq!(
-            self.expected_requests[current_request_index]
-                .method
-                .as_str(),
-            method,
-            "invalid method called"
-        );
-        assert_eq!(
-            self.expected_requests[current_request_index].params, params,
-            "invalid method params at request #{}",
-            current_request_index
-        );
-        self.actual_requests
-            .as_ref()
-            .borrow_mut()
-            .push(RequestData {
-                method: method.to_string(),
-                params: params.clone(),
-            });
+		assert_eq!(
+			self.expected_requests[current_request_index]
+				.method
+				.as_str(),
+			method,
+			"invalid method called"
+		);
+		assert_eq!(
+			self.expected_requests[current_request_index].params, params,
+			"invalid method params at request #{}",
+			current_request_index
+		);
+		self.actual_requests
+			.as_ref()
+			.borrow_mut()
+			.push(RequestData {
+				method: method.to_string(),
+				params: params.clone(),
+			});
 
-        let request = web3::helpers::build_request(1, method, params);
-        (current_request_index + 1, request)
-    }
+		let request = web3::helpers::build_request(1, method, params);
+		(current_request_index + 1, request)
+	}
 
-    fn send(&self, _id: usize, _request: jsonrpc_core::Call) -> web3::Result<jsonrpc_core::Value> {
-        let current_request_index = { self.actual_requests.as_ref().borrow().len() };
-        let response = self
-            .mock_responses
-            .iter()
-            .nth(current_request_index - 1)
-            .expect("missing response");
-        let f = futures::finished(response.clone());
-        Box::new(f)
-    }
+	fn send(&self, _id: usize, _request: jsonrpc_core::Call) -> web3::Result<jsonrpc_core::Value> {
+		let current_request_index = { self.actual_requests.as_ref().borrow().len() };
+		let response = self
+			.mock_responses
+			.iter()
+			.nth(current_request_index - 1)
+			.expect("missing response");
+		let f = futures::finished(response.clone());
+		Box::new(f)
+	}
 }
 
 #[macro_export]
 macro_rules! mock_transport {
-    (
-        $($method: expr => req => $req: expr, res => $res: expr ;)*
-    ) => {
-        $crate::MockTransport {
-            actual_requests: Default::default(),
-            expected_requests: vec![$($method),*]
-                .into_iter()
-                .zip(vec![$($req),*]
-                .into_iter())
-                .map(Into::into)
-                .collect(),
-            mock_responses: vec![$($res),*],
-        }
-    }
+	(
+		$($method: expr => req => $req: expr, res => $res: expr ;)*
+	) => {
+		$crate::MockTransport {
+			actual_requests: Default::default(),
+			expected_requests: vec![$($method),*]
+				.into_iter()
+				.zip(vec![$($req),*]
+				.into_iter())
+				.map(Into::into)
+				.collect(),
+			mock_responses: vec![$($res),*],
+		}
+	}
 }

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -16,12 +16,12 @@
 use std::process::Command;
 
 fn main() {
-    // make last git commit hash (`git rev-parse HEAD`)
-    // available via `env!("GIT_HASH")` in sources
-    let output = Command::new("git")
-        .args(&["rev-parse", "HEAD"])
-        .output()
-        .expect("`git rev-parse HEAD` failed to run. run it yourself to verify. file an issue if this persists");
-    let git_hash = String::from_utf8(output.stdout).unwrap();
-    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+	// make last git commit hash (`git rev-parse HEAD`)
+	// available via `env!("GIT_HASH")` in sources
+	let output = Command::new("git")
+		.args(&["rev-parse", "HEAD"])
+		.output()
+		.expect("`git rev-parse HEAD` failed to run. run it yourself to verify. file an issue if this persists");
+	let git_hash = String::from_utf8(output.stdout).unwrap();
+	println!("cargo:rustc-env=GIT_HASH={}", git_hash);
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -41,132 +41,132 @@ const MAX_PARALLEL_REQUESTS: usize = 10;
 
 #[derive(Debug, Deserialize)]
 pub struct Args {
-    arg_config: PathBuf,
-    arg_database: PathBuf,
+	arg_config: PathBuf,
+	arg_database: PathBuf,
 }
 
 fn main() {
-    let _ = env_logger::init();
-    let result = execute(env::args());
+	let _ = env_logger::init();
+	let result = execute(env::args());
 
-    match result {
-        Ok(s) => println!("{}", s),
-        Err(err) => print_err(err),
-    }
+	match result {
+		Ok(s) => println!("{}", s),
+		Err(err) => print_err(err),
+	}
 }
 
 fn print_err(err: error::Error) {
-    let message = err
-        .iter()
-        .map(|e| e.to_string())
-        .collect::<Vec<_>>()
-        .join("\n\nCaused by:\n  ");
-    println!("{}", message);
+	let message = err
+		.iter()
+		.map(|e| e.to_string())
+		.collect::<Vec<_>>()
+		.join("\n\nCaused by:\n  ");
+	println!("{}", message);
 }
 
 fn execute<S, I>(command: I) -> Result<String, error::Error>
 where
-    I: IntoIterator<Item = S>,
-    S: AsRef<str>,
+	I: IntoIterator<Item = S>,
+	S: AsRef<str>,
 {
-    let usage = format!(
-        r#"
+	let usage = format!(
+		r#"
 Parity-bridge
-    Copyright 2017 Parity Technologies (UK) Limited
-    Version: {}
-    Commit: {}
+	Copyright 2017 Parity Technologies (UK) Limited
+	Version: {}
+	Commit: {}
 
 Usage:
-    parity-bridge --config <config> --database <database>
-    parity-bridge -h | --help
+	parity-bridge --config <config> --database <database>
+	parity-bridge -h | --help
 
 Options:
-    -h, --help           Display help message and exit.
+	-h, --help           Display help message and exit.
 "#,
-        env!("CARGO_PKG_VERSION"),
-        env!("GIT_HASH")
-    );
+		env!("CARGO_PKG_VERSION"),
+		env!("GIT_HASH")
+	);
 
-    info!("Parsing cli arguments");
-    let args: Args = Docopt::new(usage)
-        .and_then(|d| d.argv(command).deserialize())
-        .map_err(|e| e.to_string())?;
+	info!("Parsing cli arguments");
+	let args: Args = Docopt::new(usage)
+		.and_then(|d| d.argv(command).deserialize())
+		.map_err(|e| e.to_string())?;
 
-    info!("Loading config from {:?}", args.arg_config);
-    let config = Config::load(&args.arg_config)?;
+	info!("Loading config from {:?}", args.arg_config);
+	let config = Config::load(&args.arg_config)?;
 
-    info!("Starting event loop");
-    let mut event_loop = Core::new().unwrap();
+	info!("Starting event loop");
+	let mut event_loop = Core::new().unwrap();
 
-    info!(
-        "Establishing HTTP connection to parity node connected to main chain at {:?}",
-        config.main.http
-    );
-    let main_transport = Http::with_event_loop(
-        &config.main.http,
-        &event_loop.handle(),
-        MAX_PARALLEL_REQUESTS,
-    )
-    .chain_err(|| {
-        format!(
-            "Cannot connect to parity node connected to main chain at {}",
-            config.main.http
-        )
-    })?;
+	info!(
+		"Establishing HTTP connection to parity node connected to main chain at {:?}",
+		config.main.http
+	);
+	let main_transport = Http::with_event_loop(
+		&config.main.http,
+		&event_loop.handle(),
+		MAX_PARALLEL_REQUESTS,
+	)
+	.chain_err(|| {
+		format!(
+			"Cannot connect to parity node connected to main chain at {}",
+			config.main.http
+		)
+	})?;
 
-    info!(
-        "Establishing HTTP connection to parity node connected to side chain at {:?}",
-        config.side.http
-    );
-    let side_transport = Http::with_event_loop(
-        &config.side.http,
-        &event_loop.handle(),
-        MAX_PARALLEL_REQUESTS,
-    )
-    .chain_err(|| {
-        format!(
-            "Cannot connect to parity node connected to side chain at {}",
-            config.side.http
-        )
-    })?;
+	info!(
+		"Establishing HTTP connection to parity node connected to side chain at {:?}",
+		config.side.http
+	);
+	let side_transport = Http::with_event_loop(
+		&config.side.http,
+		&event_loop.handle(),
+		MAX_PARALLEL_REQUESTS,
+	)
+	.chain_err(|| {
+		format!(
+			"Cannot connect to parity node connected to side chain at {}",
+			config.side.http
+		)
+	})?;
 
-    info!("Loading database from {:?}", args.arg_database);
-    let mut database = TomlFileDatabase::from_path(&args.arg_database)?;
+	info!("Loading database from {:?}", args.arg_database);
+	let mut database = TomlFileDatabase::from_path(&args.arg_database)?;
 
-    info!("Reading initial state from database");
-    let initial_state = database.read();
+	info!("Reading initial state from database");
+	let initial_state = database.read();
 
-    let main_contract = bridge::MainContract::new(main_transport.clone(), &config, &initial_state);
-    event_loop
-        .run(main_contract.is_main_contract())
-        .chain_err(|| {
-            format!(
-            "call to main contract `is_main_bridge_contract` failed. this is likely due to field `main_contract_address = {}` in database file {:?} not pointing to a bridge main contract. please verify!",
-            initial_state.main_contract_address,
-            args.arg_database
-        )
-        })?;
+	let main_contract = bridge::MainContract::new(main_transport.clone(), &config, &initial_state);
+	event_loop
+		.run(main_contract.is_main_contract())
+		.chain_err(|| {
+			format!(
+			"call to main contract `is_main_bridge_contract` failed. this is likely due to field `main_contract_address = {}` in database file {:?} not pointing to a bridge main contract. please verify!",
+			initial_state.main_contract_address,
+			args.arg_database
+		)
+		})?;
 
-    let side_contract = bridge::SideContract::new(side_transport.clone(), &config, &initial_state);
-    event_loop
-        .run(side_contract.is_side_contract())
-        .chain_err(|| {
-            format!(
-            "call to side contract `is_side_bridge_contract` failed. this is likely due to field `side_contract_address = {}` in database file {:?} not pointing to a bridge side contract. please verify!",
-            initial_state.side_contract_address,
-            args.arg_database
-        )
-        })?;
+	let side_contract = bridge::SideContract::new(side_transport.clone(), &config, &initial_state);
+	event_loop
+		.run(side_contract.is_side_contract())
+		.chain_err(|| {
+			format!(
+			"call to side contract `is_side_bridge_contract` failed. this is likely due to field `side_contract_address = {}` in database file {:?} not pointing to a bridge side contract. please verify!",
+			initial_state.side_contract_address,
+			args.arg_database
+		)
+		})?;
 
-    let bridge_stream = bridge::Bridge::new(initial_state, main_contract, side_contract);
-    info!("Started polling logs");
-    let persisted_bridge_stream = bridge_stream.and_then(|state| {
-        database.write(&state)?;
-        // info!("state change: {}", state);
-        Ok(())
-    });
+	let bridge_stream = bridge::Bridge::new(initial_state, main_contract, side_contract);
+	info!("Started polling logs");
+	let persisted_bridge_stream = bridge_stream.and_then(|state| {
+		database.write(&state)?;
+		// info!("state change: {}", state);
+		Ok(())
+	});
 
-    event_loop.run(persisted_bridge_stream.last())?;
+	event_loop.run(persisted_bridge_stream.last())?;
 
-    Ok("Done".into())
+	Ok("Done".into())
 }

--- a/contracts/build.rs
+++ b/contracts/build.rs
@@ -18,29 +18,29 @@ extern crate solc;
 use std::process::Command;
 
 fn main() {
-    // rerun build script if bridge contract has changed.
-    // without this cargo doesn't since the bridge contract
-    // is outside the crate directories
-    println!("cargo:rerun-if-changed=../arbitrary/contracts/bridge.sol");
+	// rerun build script if bridge contract has changed.
+	// without this cargo doesn't since the bridge contract
+	// is outside the crate directories
+	println!("cargo:rerun-if-changed=../arbitrary/contracts/bridge.sol");
 
-    // make last git commit hash (`git rev-parse HEAD`)
-    // available via `env!("GIT_HASH")` in sources
-    let output = Command::new("git")
-        .args(&["rev-parse", "HEAD"])
-        .output()
-        .expect("`git rev-parse HEAD` failed to run. run it yourself to verify. file an issue if this persists");
-    let git_hash = String::from_utf8(output.stdout).unwrap();
-    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+	// make last git commit hash (`git rev-parse HEAD`)
+	// available via `env!("GIT_HASH")` in sources
+	let output = Command::new("git")
+		.args(&["rev-parse", "HEAD"])
+		.output()
+		.expect("`git rev-parse HEAD` failed to run. run it yourself to verify. file an issue if this persists");
+	let git_hash = String::from_utf8(output.stdout).unwrap();
+	println!("cargo:rustc-env=GIT_HASH={}", git_hash);
 
-    // make solc version used to compile contracts (`solc --version`)
-    // available via `env!("SOLC_VERSION")` in sources
-    let output = Command::new("solc").args(&["--version"]).output().expect(
-        "`solc --version` failed to run. run it yourself to verify. file an issue if this persists",
-    );
-    let output_string = String::from_utf8(output.stdout).unwrap();
-    let solc_version = output_string.lines().last().unwrap();
-    println!("cargo:rustc-env=SOLC_VERSION={}", solc_version);
+	// make solc version used to compile contracts (`solc --version`)
+	// available via `env!("SOLC_VERSION")` in sources
+	let output = Command::new("solc").args(&["--version"]).output().expect(
+		"`solc --version` failed to run. run it yourself to verify. file an issue if this persists",
+	);
+	let output_string = String::from_utf8(output.stdout).unwrap();
+	let solc_version = output_string.lines().last().unwrap();
+	println!("cargo:rustc-env=SOLC_VERSION={}", solc_version);
 
-    // compile contracts for inclusion with ethabis `use_contract!`
-    solc::solc_compile("../arbitrary/contracts/bridge.sol", "../compiled_contracts").unwrap();
+	// compile contracts for inclusion with ethabis `use_contract!`
+	solc::solc_compile("../arbitrary/contracts/bridge.sol", "../compiled_contracts").unwrap();
 }

--- a/deploy/build.rs
+++ b/deploy/build.rs
@@ -16,12 +16,12 @@
 use std::process::Command;
 
 fn main() {
-    // make last git commit hash (`git rev-parse HEAD`)
-    // available via `env!("GIT_HASH")` in sources
-    let output = Command::new("git")
-        .args(&["rev-parse", "HEAD"])
-        .output()
-        .unwrap();
-    let git_hash = String::from_utf8(output.stdout).unwrap();
-    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+	// make last git commit hash (`git rev-parse HEAD`)
+	// available via `env!("GIT_HASH")` in sources
+	let output = Command::new("git")
+		.args(&["rev-parse", "HEAD"])
+		.output()
+		.unwrap();
+	let git_hash = String::from_utf8(output.stdout).unwrap();
+	println!("cargo:rustc-env=GIT_HASH={}", git_hash);
 }

--- a/integration-tests/tests/basic_deposit_then_withdraw.rs
+++ b/integration-tests/tests/basic_deposit_then_withdraw.rs
@@ -46,419 +46,419 @@ const MAX_PARALLEL_REQUESTS: usize = 10;
 const TIMEOUT: Duration = Duration::from_secs(1);
 
 fn parity_main_command() -> Command {
-    let mut command = Command::new("parity");
-    command
-        .arg("--base-path")
-        .arg(format!("{}/main", TMP_PATH))
-        .arg("--chain")
-        .arg("./spec.json")
-        .arg("--no-ipc")
-        .arg("--logging")
-        .arg("rpc=trace,miner=trace,executive=trace")
-        .arg("--jsonrpc-port")
-        .arg("8550")
-        .arg("--jsonrpc-apis")
-        .arg("all")
-        .arg("--port")
-        .arg("30310")
-        .arg("--gasprice")
-        .arg("0")
-        .arg("--reseal-min-period")
-        .arg("0")
-        .arg("--no-ws")
-        .arg("--no-dapps")
-        .arg("--no-warp")
-        .arg("--no-ui");
-    command
+	let mut command = Command::new("parity");
+	command
+		.arg("--base-path")
+		.arg(format!("{}/main", TMP_PATH))
+		.arg("--chain")
+		.arg("./spec.json")
+		.arg("--no-ipc")
+		.arg("--logging")
+		.arg("rpc=trace,miner=trace,executive=trace")
+		.arg("--jsonrpc-port")
+		.arg("8550")
+		.arg("--jsonrpc-apis")
+		.arg("all")
+		.arg("--port")
+		.arg("30310")
+		.arg("--gasprice")
+		.arg("0")
+		.arg("--reseal-min-period")
+		.arg("0")
+		.arg("--no-ws")
+		.arg("--no-dapps")
+		.arg("--no-warp")
+		.arg("--no-ui");
+	command
 }
 
 fn parity_side_command() -> Command {
-    let mut command = Command::new("parity");
-    command
-        .arg("--base-path")
-        .arg(format!("{}/side", TMP_PATH))
-        .arg("--chain")
-        .arg("./spec.json")
-        .arg("--no-ipc")
-        .arg("--logging")
-        .arg("rpc=trace,miner=trace,executive=trace")
-        .arg("--jsonrpc-port")
-        .arg("8551")
-        .arg("--jsonrpc-apis")
-        .arg("all")
-        .arg("--port")
-        .arg("30311")
-        .arg("--gasprice")
-        .arg("0")
-        .arg("--reseal-min-period")
-        .arg("0")
-        .arg("--no-ws")
-        .arg("--no-dapps")
-        .arg("--no-warp")
-        .arg("--no-ui");
-    command
+	let mut command = Command::new("parity");
+	command
+		.arg("--base-path")
+		.arg(format!("{}/side", TMP_PATH))
+		.arg("--chain")
+		.arg("./spec.json")
+		.arg("--no-ipc")
+		.arg("--logging")
+		.arg("rpc=trace,miner=trace,executive=trace")
+		.arg("--jsonrpc-port")
+		.arg("8551")
+		.arg("--jsonrpc-apis")
+		.arg("all")
+		.arg("--port")
+		.arg("30311")
+		.arg("--gasprice")
+		.arg("0")
+		.arg("--reseal-min-period")
+		.arg("0")
+		.arg("--no-ws")
+		.arg("--no-dapps")
+		.arg("--no-warp")
+		.arg("--no-ui");
+	command
 }
 
 #[test]
 fn test_basic_deposit_then_withdraw() {
-    if Path::new(TMP_PATH).exists() {
-        std::fs::remove_dir_all(TMP_PATH).expect("failed to remove tmp dir");
-    }
-    let _ = std::fs::create_dir_all(TMP_PATH).expect("failed to create tmp dir");
-    let _tmp_dir = tempfile::TempDir::new_in(TMP_PATH).expect("failed to create tmp dir");
+	if Path::new(TMP_PATH).exists() {
+		std::fs::remove_dir_all(TMP_PATH).expect("failed to remove tmp dir");
+	}
+	let _ = std::fs::create_dir_all(TMP_PATH).expect("failed to create tmp dir");
+	let _tmp_dir = tempfile::TempDir::new_in(TMP_PATH).expect("failed to create tmp dir");
 
-    println!("\nbuild the deploy executable so we can run it later\n");
-    assert!(Command::new("cargo")
-        .env("RUST_BACKTRACE", "1")
-        .current_dir("../deploy")
-        .arg("build")
-        .status()
-        .expect("failed to build parity-bridge-deploy executable")
-        .success());
+	println!("\nbuild the deploy executable so we can run it later\n");
+	assert!(Command::new("cargo")
+		.env("RUST_BACKTRACE", "1")
+		.current_dir("../deploy")
+		.arg("build")
+		.status()
+		.expect("failed to build parity-bridge-deploy executable")
+		.success());
 
-    println!("\nbuild the parity-bridge executable so we can run it later\n");
-    assert!(Command::new("cargo")
-        .env("RUST_BACKTRACE", "1")
-        .current_dir("../cli")
-        .arg("build")
-        .status()
-        .expect("failed to build parity-bridge executable")
-        .success());
+	println!("\nbuild the parity-bridge executable so we can run it later\n");
+	assert!(Command::new("cargo")
+		.env("RUST_BACKTRACE", "1")
+		.current_dir("../cli")
+		.arg("build")
+		.status()
+		.expect("failed to build parity-bridge executable")
+		.success());
 
-    // start a parity node that represents the main chain
-    let mut parity_main = parity_main_command()
-        .spawn()
-        .expect("failed to spawn parity main node");
+	// start a parity node that represents the main chain
+	let mut parity_main = parity_main_command()
+		.spawn()
+		.expect("failed to spawn parity main node");
 
-    // start a parity node that represents the side chain
-    let mut parity_side = parity_side_command()
-        .spawn()
-        .expect("failed to spawn parity side node");
+	// start a parity node that represents the side chain
+	let mut parity_side = parity_side_command()
+		.spawn()
+		.expect("failed to spawn parity side node");
 
-    // give the clients time to start up
-    thread::sleep(Duration::from_millis(3000));
+	// give the clients time to start up
+	thread::sleep(Duration::from_millis(3000));
 
-    let user_address = "004ec07d2329997267ec62b4166639513386f32e";
-    let authority_address = "00bd138abd70e2f00903268f3db08f2d25677c9e";
+	let user_address = "004ec07d2329997267ec62b4166639513386f32e";
+	let authority_address = "00bd138abd70e2f00903268f3db08f2d25677c9e";
 
-    let main_contract_address = "ebd3944af37ccc6b67ff61239ac4fef229c8f69f";
-    let side_contract_address = "ebd3944af37ccc6b67ff61239ac4fef229c8f69f";
-    // Note this has to be the first contract created by `user_address`
-    let main_recipient_address = "5f3dba5e45909d1bf126aa0af0601b1a369dbfd7";
-    let side_recipient_address = "5f3dba5e45909d1bf126aa0af0601b1a369dbfd7";
+	let main_contract_address = "ebd3944af37ccc6b67ff61239ac4fef229c8f69f";
+	let side_contract_address = "ebd3944af37ccc6b67ff61239ac4fef229c8f69f";
+	// Note this has to be the first contract created by `user_address`
+	let main_recipient_address = "5f3dba5e45909d1bf126aa0af0601b1a369dbfd7";
+	let side_recipient_address = "5f3dba5e45909d1bf126aa0af0601b1a369dbfd7";
 
-    let data_to_relay_to_side = vec![0u8, 1, 5];
-    let data_to_relay_to_main = vec![0u8, 1, 5, 7];
+	let data_to_relay_to_side = vec![0u8, 1, 5];
+	let data_to_relay_to_main = vec![0u8, 1, 5, 7];
 
-    fn new_account(phrase: &str, port: u16) {
-        // this is currently not supported in web3 crate so we have to use curl
-        let exit_status = Command::new("curl")
-            .arg("--data")
-            .arg(format!(
-                "{}{}{}",
-                r#"{"jsonrpc":"2.0","method":"parity_newAccountFromPhrase","params":[""#,
-                phrase,
-                r#"", ""],"id":0}"#,
-            ))
-            .arg("-H")
-            .arg("Content-Type: application/json")
-            .arg("-X")
-            .arg("POST")
-            .arg(format!("localhost:{}", port))
-            .status()
-            .expect("failed to create authority account on main");
-        assert!(exit_status.success());
-    }
+	fn new_account(phrase: &str, port: u16) {
+		// this is currently not supported in web3 crate so we have to use curl
+		let exit_status = Command::new("curl")
+			.arg("--data")
+			.arg(format!(
+				"{}{}{}",
+				r#"{"jsonrpc":"2.0","method":"parity_newAccountFromPhrase","params":[""#,
+				phrase,
+				r#"", ""],"id":0}"#,
+			))
+			.arg("-H")
+			.arg("Content-Type: application/json")
+			.arg("-X")
+			.arg("POST")
+			.arg(format!("localhost:{}", port))
+			.status()
+			.expect("failed to create authority account on main");
+		assert!(exit_status.success());
+	}
 
-    // create authority account on main
-    new_account("node0", 8550);
-    new_account("user", 8550);
-    // TODO [snd] assert that created address matches authority_address
+	// create authority account on main
+	new_account("node0", 8550);
+	new_account("user", 8550);
+	// TODO [snd] assert that created address matches authority_address
 
-    // TODO don't shell out to curl
-    // create authority account on side
-    new_account("node0", 8551);
-    new_account("user", 8551);
-    // TODO [snd] assert that created address matches authority_address
+	// TODO don't shell out to curl
+	// create authority account on side
+	new_account("node0", 8551);
+	new_account("user", 8551);
+	// TODO [snd] assert that created address matches authority_address
 
-    // give the operations time to complete
-    thread::sleep(Duration::from_millis(5000));
+	// give the operations time to complete
+	thread::sleep(Duration::from_millis(5000));
 
-    // kill the clients so we can restart them with the accounts unlocked
-    parity_main.kill().unwrap();
-    parity_side.kill().unwrap();
+	// kill the clients so we can restart them with the accounts unlocked
+	parity_main.kill().unwrap();
+	parity_side.kill().unwrap();
 
-    // wait for clients to shut down
-    thread::sleep(Duration::from_millis(5000));
+	// wait for clients to shut down
+	thread::sleep(Duration::from_millis(5000));
 
-    // start a parity node that represents the main chain with accounts unlocked
-    let mut parity_main = parity_main_command()
-        .arg("--unlock")
-        .arg(format!("0x{},0x{}", user_address, authority_address))
-        .arg("--password")
-        .arg("password.txt")
-        .spawn()
-        .expect("failed to spawn parity main node");
+	// start a parity node that represents the main chain with accounts unlocked
+	let mut parity_main = parity_main_command()
+		.arg("--unlock")
+		.arg(format!("0x{},0x{}", user_address, authority_address))
+		.arg("--password")
+		.arg("password.txt")
+		.spawn()
+		.expect("failed to spawn parity main node");
 
-    // start a parity node that represents the side chain with accounts unlocked
-    let mut parity_side = parity_side_command()
-        .arg("--unlock")
-        .arg(format!("0x{},0x{}", user_address, authority_address))
-        .arg("--password")
-        .arg("password.txt")
-        .spawn()
-        .expect("failed to spawn parity side node");
+	// start a parity node that represents the side chain with accounts unlocked
+	let mut parity_side = parity_side_command()
+		.arg("--unlock")
+		.arg(format!("0x{},0x{}", user_address, authority_address))
+		.arg("--password")
+		.arg("password.txt")
+		.spawn()
+		.expect("failed to spawn parity side node");
 
-    // give nodes time to start up
-    thread::sleep(Duration::from_millis(10000));
+	// give nodes time to start up
+	thread::sleep(Duration::from_millis(10000));
 
-    // deploy bridge contracts
+	// deploy bridge contracts
 
-    println!("\ndeploying contracts\n");
-    assert!(Command::new("env")
-        .arg("RUST_BACKTRACE=1")
-        .arg("../target/debug/parity-bridge-deploy")
-        .env("RUST_LOG", "info")
-        .arg("--config")
-        .arg("bridge_config.toml")
-        .arg("--database")
-        .arg("tmp/bridge1_db.txt")
-        .status()
-        .expect("failed spawn parity-bridge-deploy")
-        .success());
+	println!("\ndeploying contracts\n");
+	assert!(Command::new("env")
+		.arg("RUST_BACKTRACE=1")
+		.arg("../target/debug/parity-bridge-deploy")
+		.env("RUST_LOG", "info")
+		.arg("--config")
+		.arg("bridge_config.toml")
+		.arg("--database")
+		.arg("tmp/bridge1_db.txt")
+		.status()
+		.expect("failed spawn parity-bridge-deploy")
+		.success());
 
-    // start bridge authority 1
-    let mut bridge1 = Command::new("env")
-        .arg("RUST_BACKTRACE=1")
-        .arg("../target/debug/parity-bridge")
-        .env("RUST_LOG", "info")
-        .arg("--config")
-        .arg("bridge_config.toml")
-        .arg("--database")
-        .arg("tmp/bridge1_db.txt")
-        .spawn()
-        .expect("failed to spawn bridge process");
+	// start bridge authority 1
+	let mut bridge1 = Command::new("env")
+		.arg("RUST_BACKTRACE=1")
+		.arg("../target/debug/parity-bridge")
+		.env("RUST_LOG", "info")
+		.arg("--config")
+		.arg("bridge_config.toml")
+		.arg("--database")
+		.arg("tmp/bridge1_db.txt")
+		.spawn()
+		.expect("failed to spawn bridge process");
 
-    let mut event_loop = Core::new().unwrap();
+	let mut event_loop = Core::new().unwrap();
 
-    // connect to main
-    let main_transport = Http::with_event_loop(
-        "http://localhost:8550",
-        &event_loop.handle(),
-        MAX_PARALLEL_REQUESTS,
-    )
-    .expect("failed to connect to main at http://localhost:8550");
+	// connect to main
+	let main_transport = Http::with_event_loop(
+		"http://localhost:8550",
+		&event_loop.handle(),
+		MAX_PARALLEL_REQUESTS,
+	)
+	.expect("failed to connect to main at http://localhost:8550");
 
-    // connect to side
-    let side_transport = Http::with_event_loop(
-        "http://localhost:8551",
-        &event_loop.handle(),
-        MAX_PARALLEL_REQUESTS,
-    )
-    .expect("failed to connect to side at http://localhost:8551");
+	// connect to side
+	let side_transport = Http::with_event_loop(
+		"http://localhost:8551",
+		&event_loop.handle(),
+		MAX_PARALLEL_REQUESTS,
+	)
+	.expect("failed to connect to side at http://localhost:8551");
 
-    println!("\ngive authority some funds to do relay later\n");
+	println!("\ngive authority some funds to do relay later\n");
 
-    event_loop
-        .run(web3::confirm::send_transaction_with_confirmation(
-            &main_transport,
-            web3::types::TransactionRequest {
-                from: user_address.parse().unwrap(),
-                to: Some(authority_address.parse().unwrap()),
-                gas: None,
-                gas_price: None,
-                value: Some(1000000000.into()),
-                data: None,
-                condition: None,
-                nonce: None,
-            },
-            Duration::from_secs(1),
-            0,
-        ))
-        .unwrap();
+	event_loop
+		.run(web3::confirm::send_transaction_with_confirmation(
+			&main_transport,
+			web3::types::TransactionRequest {
+				from: user_address.parse().unwrap(),
+				to: Some(authority_address.parse().unwrap()),
+				gas: None,
+				gas_price: None,
+				value: Some(1000000000.into()),
+				data: None,
+				condition: None,
+				nonce: None,
+			},
+			Duration::from_secs(1),
+			0,
+		))
+		.unwrap();
 
-    event_loop
-        .run(web3::confirm::send_transaction_with_confirmation(
-            &side_transport,
-            web3::types::TransactionRequest {
-                from: user_address.parse().unwrap(),
-                to: Some(authority_address.parse().unwrap()),
-                gas: None,
-                gas_price: None,
-                value: Some(1000000000.into()),
-                data: None,
-                condition: None,
-                nonce: None,
-            },
-            Duration::from_secs(1),
-            0,
-        ))
-        .unwrap();
+	event_loop
+		.run(web3::confirm::send_transaction_with_confirmation(
+			&side_transport,
+			web3::types::TransactionRequest {
+				from: user_address.parse().unwrap(),
+				to: Some(authority_address.parse().unwrap()),
+				gas: None,
+				gas_price: None,
+				value: Some(1000000000.into()),
+				data: None,
+				condition: None,
+				nonce: None,
+			},
+			Duration::from_secs(1),
+			0,
+		))
+		.unwrap();
 
-    println!("\ndeploy BridgeRecipient contracts\n");
+	println!("\ndeploy BridgeRecipient contracts\n");
 
-    event_loop
-        .run(web3::confirm::send_transaction_with_confirmation(
-            &main_transport,
-            web3::types::TransactionRequest {
-                from: user_address.parse().unwrap(),
-                to: None,
-                gas: None,
-                gas_price: None,
-                value: None,
-                data: Some(
-                    include_str!("../../compiled_contracts/RecipientTest.bin")
-                        .from_hex::<Vec<u8>>()
-                        .unwrap()
-                        .into(),
-                ),
-                condition: None,
-                nonce: None,
-            },
-            Duration::from_secs(1),
-            0,
-        ))
-        .unwrap();
+	event_loop
+		.run(web3::confirm::send_transaction_with_confirmation(
+			&main_transport,
+			web3::types::TransactionRequest {
+				from: user_address.parse().unwrap(),
+				to: None,
+				gas: None,
+				gas_price: None,
+				value: None,
+				data: Some(
+					include_str!("../../compiled_contracts/RecipientTest.bin")
+						.from_hex::<Vec<u8>>()
+						.unwrap()
+						.into(),
+				),
+				condition: None,
+				nonce: None,
+			},
+			Duration::from_secs(1),
+			0,
+		))
+		.unwrap();
 
-    event_loop
-        .run(web3::confirm::send_transaction_with_confirmation(
-            &side_transport,
-            web3::types::TransactionRequest {
-                from: user_address.parse().unwrap(),
-                to: None,
-                gas: None,
-                gas_price: None,
-                value: None,
-                data: Some(
-                    include_str!("../../compiled_contracts/RecipientTest.bin")
-                        .from_hex::<Vec<u8>>()
-                        .unwrap()
-                        .into(),
-                ),
-                condition: None,
-                nonce: None,
-            },
-            Duration::from_secs(1),
-            0,
-        ))
-        .unwrap();
+	event_loop
+		.run(web3::confirm::send_transaction_with_confirmation(
+			&side_transport,
+			web3::types::TransactionRequest {
+				from: user_address.parse().unwrap(),
+				to: None,
+				gas: None,
+				gas_price: None,
+				value: None,
+				data: Some(
+					include_str!("../../compiled_contracts/RecipientTest.bin")
+						.from_hex::<Vec<u8>>()
+						.unwrap()
+						.into(),
+				),
+				condition: None,
+				nonce: None,
+			},
+			Duration::from_secs(1),
+			0,
+		))
+		.unwrap();
 
-    println!("\nSend the message to main chain and wait for the relay to side\n");
+	println!("\nSend the message to main chain and wait for the relay to side\n");
 
-    let (payload, _) = bridge_contracts::main::functions::relay_message::call(
-        data_to_relay_to_side.clone(),
-        main_recipient_address.parse::<Address>().unwrap(),
-    );
+	let (payload, _) = bridge_contracts::main::functions::relay_message::call(
+		data_to_relay_to_side.clone(),
+		main_recipient_address.parse::<Address>().unwrap(),
+	);
 
-    event_loop
-        .run(web3::confirm::send_transaction_with_confirmation(
-            &main_transport,
-            web3::types::TransactionRequest {
-                from: user_address.parse().unwrap(),
-                to: Some(main_contract_address.parse().unwrap()),
-                gas: None,
-                gas_price: None,
-                value: None,
-                data: Some(payload.into()),
-                condition: None,
-                nonce: None,
-            },
-            Duration::from_secs(1),
-            0,
-        ))
-        .unwrap();
+	event_loop
+		.run(web3::confirm::send_transaction_with_confirmation(
+			&main_transport,
+			web3::types::TransactionRequest {
+				from: user_address.parse().unwrap(),
+				to: Some(main_contract_address.parse().unwrap()),
+				gas: None,
+				gas_price: None,
+				value: None,
+				data: Some(payload.into()),
+				condition: None,
+				nonce: None,
+			},
+			Duration::from_secs(1),
+			0,
+		))
+		.unwrap();
 
-    println!(
-        "\nSending message to main complete. Give it plenty of time to get mined and relayed\n"
-    );
-    thread::sleep(Duration::from_millis(10000));
+	println!(
+		"\nSending message to main complete. Give it plenty of time to get mined and relayed\n"
+	);
+	thread::sleep(Duration::from_millis(10000));
 
-    let (payload, decoder) = bridge_contracts::test::functions::last_data::call();
+	let (payload, decoder) = bridge_contracts::test::functions::last_data::call();
 
-    let response = event_loop
-        .run(AsyncCall::new(
-            &side_transport,
-            side_recipient_address.parse().unwrap(),
-            TIMEOUT,
-            payload,
-            decoder,
-        ))
-        .unwrap();
+	let response = event_loop
+		.run(AsyncCall::new(
+			&side_transport,
+			side_recipient_address.parse().unwrap(),
+			TIMEOUT,
+			payload,
+			decoder,
+		))
+		.unwrap();
 
-    assert_eq!(
-        response, data_to_relay_to_side,
-        "data was not relayed properly to the side chain"
-    );
+	assert_eq!(
+		response, data_to_relay_to_side,
+		"data was not relayed properly to the side chain"
+	);
 
-    println!("\nSend the message to side chain and wait for the relay to main\n");
+	println!("\nSend the message to side chain and wait for the relay to main\n");
 
-    let (payload, _) = bridge_contracts::side::functions::relay_message::call(
-        data_to_relay_to_main.clone(),
-        main_recipient_address.parse::<Address>().unwrap(),
-    );
+	let (payload, _) = bridge_contracts::side::functions::relay_message::call(
+		data_to_relay_to_main.clone(),
+		main_recipient_address.parse::<Address>().unwrap(),
+	);
 
-    event_loop
-        .run(web3::confirm::send_transaction_with_confirmation(
-            &side_transport,
-            web3::types::TransactionRequest {
-                from: user_address.parse().unwrap(),
-                to: Some(side_contract_address.parse().unwrap()),
-                gas: None,
-                gas_price: None,
-                value: None,
-                data: Some(payload.into()),
-                condition: None,
-                nonce: None,
-            },
-            Duration::from_secs(1),
-            0,
-        ))
-        .unwrap();
+	event_loop
+		.run(web3::confirm::send_transaction_with_confirmation(
+			&side_transport,
+			web3::types::TransactionRequest {
+				from: user_address.parse().unwrap(),
+				to: Some(side_contract_address.parse().unwrap()),
+				gas: None,
+				gas_price: None,
+				value: None,
+				data: Some(payload.into()),
+				condition: None,
+				nonce: None,
+			},
+			Duration::from_secs(1),
+			0,
+		))
+		.unwrap();
 
-    println!(
-        "\nSending message to side complete. Give it plenty of time to get mined and relayed\n"
-    );
-    thread::sleep(Duration::from_millis(15000));
+	println!(
+		"\nSending message to side complete. Give it plenty of time to get mined and relayed\n"
+	);
+	thread::sleep(Duration::from_millis(15000));
 
-    //dwd
+	//dwd
 
-    //let main_web3 = web3::Web3::new(&main_transport);
-    //let code_future = main_web3.eth().code(main_recipient_address.into(), None);
-    //let code = event_loop.run(code_future).unwrap();
-    //println!("code: {:?}", code);
+	//let main_web3 = web3::Web3::new(&main_transport);
+	//let code_future = main_web3.eth().code(main_recipient_address.into(), None);
+	//let code = event_loop.run(code_future).unwrap();
+	//println!("code: {:?}", code);
 
-    //// TODO: remove
-    //bridge1.kill().unwrap();
+	//// TODO: remove
+	//bridge1.kill().unwrap();
 
-    //// wait for bridge to shut down
-    //thread::sleep(Duration::from_millis(1000));
-    //parity_main.kill().unwrap();
-    //parity_side.kill().unwrap();
+	//// wait for bridge to shut down
+	//thread::sleep(Duration::from_millis(1000));
+	//parity_main.kill().unwrap();
+	//parity_side.kill().unwrap();
 
-    //assert!(false);
+	//assert!(false);
 
-    let (payload, decoder) = bridge_contracts::test::functions::last_data::call();
+	let (payload, decoder) = bridge_contracts::test::functions::last_data::call();
 
-    let response = event_loop
-        .run(AsyncCall::new(
-            &main_transport,
-            main_recipient_address.parse().unwrap(),
-            TIMEOUT,
-            payload,
-            decoder,
-        ))
-        .unwrap();
+	let response = event_loop
+		.run(AsyncCall::new(
+			&main_transport,
+			main_recipient_address.parse().unwrap(),
+			TIMEOUT,
+			payload,
+			decoder,
+		))
+		.unwrap();
 
-    assert_eq!(
-        response, data_to_relay_to_main,
-        "data was not relayed properly to the main chain"
-    );
+	assert_eq!(
+		response, data_to_relay_to_main,
+		"data was not relayed properly to the main chain"
+	);
 
-    bridge1.kill().unwrap();
+	bridge1.kill().unwrap();
 
-    // wait for bridge to shut down
-    thread::sleep(Duration::from_millis(1000));
+	// wait for bridge to shut down
+	thread::sleep(Duration::from_millis(1000));
 
-    parity_main.kill().unwrap();
-    parity_side.kill().unwrap();
+	parity_main.kill().unwrap();
+	parity_side.kill().unwrap();
 }

--- a/parity-ethereum-grandpa-builtin/src/lib.rs
+++ b/parity-ethereum-grandpa-builtin/src/lib.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
+	#[test]
+	fn it_works() {
+		assert_eq!(2 + 2, 4);
+	}
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+tab_spaces=4
+hard_tabs=true

--- a/srml-bridge-poa/src/lib.rs
+++ b/srml-bridge-poa/src/lib.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
+	#[test]
+	fn it_works() {
+		assert_eq!(2 + 2, 4);
+	}
 }


### PR DESCRIPTION
(I do not have anything against spaces, but we're using tabs in all other repos && I feel a bit uneasy when switching editor tabs from parity-ethereum to parity-bridge)